### PR TITLE
Feat/#12 Apple Login 초기 설정 및 테스트

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -26,9 +26,14 @@ const LoginPage = () => {
           <button onClick={() => signOut()}>logout</button>
         </>
       ) : (
-        <button onClick={() => signIn('kakao', { callbackUrl: '/home' })}>
-          login
-        </button>
+        <>
+          <button onClick={() => signIn('kakao', { callbackUrl: '/home' })}>
+            카카오 로그인
+          </button>
+          <button onClick={() => signIn('apple', { callbackUrl: '/home' })}>
+            애플 로그인
+          </button>
+        </>
       )}
     </LoginWrapper>
   );

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -27,8 +27,11 @@ const authOptions: NextAuthOptions = {
       clientSecret: process.env.KAKAO_CLIENT_SECRET as string,
     }),
     AppleProvider({
-      clientId: process.env.APPLE_CLIENT_ID!,
-      clientSecret: await getAppleToken(),
+      clientId: process.env.APPLE_ID!,
+      clientSecret: {
+        async: true,
+        token: getAppleToken,
+      } as unknown as string,
       profile(profile: AppleProfile) {
         return {
           id: profile.sub,

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,24 @@
 import NextAuth, { NextAuthOptions } from 'next-auth';
 import KakaoProvider from 'next-auth/providers/kakao';
+import AppleProvider, { AppleProfile } from 'next-auth/providers/apple';
+import { createPrivateKey } from 'crypto';
+import { SignJWT } from 'jose';
+
+// 애플 토큰 생성 함수
+const getAppleToken = async () => {
+  const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_PRIVATE_KEY}\n-----END PRIVATE KEY-----`;
+  return await new SignJWT({})
+    .setAudience('https://appleid.apple.com')
+    .setIssuer(process.env.APPLE_TEAM_ID!)
+    .setIssuedAt(new Date().getTime() / 1000)
+    .setExpirationTime(new Date().getTime() / 1000 + 3600 * 2)
+    .setSubject(process.env.APPLE_ID!)
+    .setProtectedHeader({
+      alg: 'ES256',
+      kid: process.env.APPLE_KEY_ID,
+    })
+    .sign(createPrivateKey(key));
+};
 
 const authOptions: NextAuthOptions = {
   providers: [
@@ -7,7 +26,32 @@ const authOptions: NextAuthOptions = {
       clientId: process.env.KAKAO_CLIENT_ID as string,
       clientSecret: process.env.KAKAO_CLIENT_SECRET as string,
     }),
+    AppleProvider({
+      clientId: process.env.APPLE_CLIENT_ID!,
+      clientSecret: await getAppleToken(),
+      profile(profile: AppleProfile) {
+        return {
+          id: profile.sub,
+          email: profile.email,
+          from: 'apple',
+        };
+      },
+    }),
   ],
+
+  // Apple 로그인을 위한 쿠키 설정
+  cookies: {
+    pkceCodeVerifier: {
+      name: 'next-auth.pkce.code_verifier',
+      options: {
+        httpOnly: true,
+        sameSite: 'none',
+        path: '/',
+        secure: true,
+      },
+    },
+  },
+
   session: {
     strategy: 'jwt', //JWT 기반 인증
     maxAge: 24 * 60 * 60, // 24시간

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#12 

## 📝 작업 내용
- Apple 로그인 구현을 위한 환경 설정(.env)
- Apple Token 생성 함수 구현
- Apple Login 시에만 토큰이 발행되도록 비동기 설정 (카카오는 해당 X)
- Apple Login 쿠키 설정

### 📸 스크린샷

<img width="892" alt="스크린샷 2024-12-31 오전 12 59 11" src="https://github.com/user-attachments/assets/8855c92d-fa08-441f-9b46-3edb56995337" />
Apple Login은 http 환경에서 테스트 할 수 없기에, 배포 환경에서 테스트 할 예정입니다.

## 💬 리뷰 요구사항
카카오 로그인과 달리 Apple Login에서는 토큰을 생성해주어야합니다. (애플 개발자 센터)
노션에 정리해둔 .env 파일을 바탕으로 
1. 개인키 형식 구성 
2. JWT 토큰 생성 및 설정(사용처/발행자/발행시간 2시간 -> 정해진 규정)
순으로 작성하였고, 애플 로그인 시 쿠키옵션 적용해 주어야 callbackUrl이 정상 작동하기에 쿠키 설정까지 완료했습니다.

배포 환경에서 테스트 후 발생하는 문제에 대해서 추가 이슈를 통해 진행할 예정입니다.
   