### PR TITLE
Feat/#12 getAppleToken 호출 비동기 함수설정

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,6 @@
 import NextAuth, { NextAuthOptions } from 'next-auth';
 import KakaoProvider from 'next-auth/providers/kakao';
-import AppleProvider, { AppleProfile } from 'next-auth/providers/apple';
+import AppleProvider from 'next-auth/providers/apple';
 import { createPrivateKey } from 'crypto';
 import { SignJWT } from 'jose';
 
@@ -46,18 +46,7 @@ const authOptions: NextAuthOptions = {
           return token;
         },
       } as unknown as string,
-      authorization: {
-        params: {
-          scope: 'name email',
-          response_mode: 'form_post',
-          response_type: 'code',
-          redirect_uri: 'https://urdego.vercel.app/api/auth/callback/apple',
-        },
-      },
-      profile(profile: AppleProfile) {
-        console.log('애플 프로필 데이터:', profile);
-        console.log('애플 프로필 sub:', profile.sub);
-        console.log('애플 프로필 email:', profile.email);
+      profile(profile) {
         return {
           id: profile.sub,
           email: profile.email,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#12 

## 📝 작업 내용
- AppleProvider의 clientSecret을 비동기 함수로 설정하여 getAppleToken을 호출하도록 수정

- callbacks에서 jwt와 session을 업데이트하여 토큰과 세션 정보를 관리