### PR TITLE
Feat/#12 login apple

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -19,6 +19,8 @@ const getAppleToken = async () => {
     })
     .sign(createPrivateKey(key));
 };
+// Apple 토큰을 미리 생성
+const appleClientSecret = await getAppleToken();
 
 const authOptions: NextAuthOptions = {
   debug: true, // 디버그 모드 활성화
@@ -37,15 +39,7 @@ const authOptions: NextAuthOptions = {
     }),
     AppleProvider({
       clientId: process.env.APPLE_ID!,
-      clientSecret: {
-        async: true,
-        token: async () => {
-          console.log('애플 토큰 생성 시작');
-          const token = await getAppleToken();
-          console.log('생성된 애플 토큰:', token);
-          return token;
-        },
-      } as unknown as string,
+      clientSecret: appleClientSecret,
       authorization: {
         params: {
           scope: 'name email',

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -46,6 +46,14 @@ const authOptions: NextAuthOptions = {
           return token;
         },
       } as unknown as string,
+      authorization: {
+        params: {
+          scope: 'name email',
+          response_mode: 'form_post',
+          response_type: 'code',
+          redirect_uri: '/api/auth/callback/apple',
+        },
+      },
       profile(profile) {
         return {
           id: profile.sub,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#12 

## 📝 작업 내용
![image](https://github.com/user-attachments/assets/31b47e9c-8bd4-4e54-b0f4-d88f32679b71)

- AppleProvider의 clientSecret을 설정할 때 비동기 함수 getAppleToken()을 호출하는 부분에서 문제가 발생
 - authOptions 객체 동기적으로 생성 -> getAppleToken()을 호출하여 clientSecret을 미리 생성한 후에 authOptions에 전달



