### PR TITLE
Hotfix/#12 애플 토큰 생성 정상화 테스트

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -7,7 +7,7 @@ import { SignJWT } from 'jose';
 // 애플 토큰 생성 함수
 const getAppleToken = async () => {
   const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_PRIVATE_KEY}\n-----END PRIVATE KEY-----`;
-  return await new SignJWT({})
+  const token = await new SignJWT({})
     .setAudience('https://appleid.apple.com')
     .setIssuer(process.env.APPLE_TEAM_ID!)
     .setIssuedAt(new Date().getTime() / 1000)
@@ -18,7 +18,11 @@ const getAppleToken = async () => {
       kid: process.env.APPLE_KEY_ID,
     })
     .sign(createPrivateKey(key));
+
+  console.log('Generated Apple Client Secret:', token); // 토큰 로그 출력
+  return token;
 };
+
 // Apple 토큰을 미리 생성
 const appleClientSecret = await getAppleToken();
 
@@ -45,7 +49,7 @@ const authOptions: NextAuthOptions = {
           scope: 'name email',
           response_mode: 'form_post',
           response_type: 'code',
-          redirect_uri: '/api/auth/callback/apple',
+          redirect_uri: process.env.NEXTAUTH_URL + '/api/auth/callback/apple',
         },
       },
       profile(profile) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#12 

## 📝 작업 내용
기존 작업과 동일합니다. (배포 연동이 느려 추가 수정했던 것을 복원하였습니다.)
```
// 애플 토큰 생성 함수
const getAppleToken = async () => {
  const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_PRIVATE_KEY}\n-----END PRIVATE KEY-----`;
  const token = await new SignJWT({})
    .setAudience('https://appleid.apple.com')
    .setIssuer(process.env.APPLE_TEAM_ID!)
    .setIssuedAt(new Date().getTime() / 1000)
    .setExpirationTime(new Date().getTime() / 1000 + 3600 * 2)
    .setSubject(process.env.APPLE_ID!)
    .setProtectedHeader({
      alg: 'ES256',
      kid: process.env.APPLE_KEY_ID,
    })
    .sign(createPrivateKey(key));

  console.log('Generated Apple Client Secret:', token); // 토큰 로그 출력
  return token;
};
```

