### PR TITLE
Fix/#12 애플 토큰 생성 오류를 찾기 위한 디버깅

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -7,7 +7,7 @@ import { SignJWT } from 'jose';
 // 애플 토큰 생성 함수
 const getAppleToken = async () => {
   const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_PRIVATE_KEY}\n-----END PRIVATE KEY-----`;
-  const token = await new SignJWT({})
+  return await new SignJWT({})
     .setAudience('https://appleid.apple.com')
     .setIssuer(process.env.APPLE_TEAM_ID!)
     .setIssuedAt(new Date().getTime() / 1000)
@@ -18,9 +18,6 @@ const getAppleToken = async () => {
       kid: process.env.APPLE_KEY_ID,
     })
     .sign(createPrivateKey(key));
-
-  console.log('Generated Apple Client Secret:', token); // 토큰 로그 출력
-  return token;
 };
 
 // Apple 토큰을 미리 생성


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#12 
## 📝 작업 내용

### ⏰ Apple Login Error 해결 과정
1. ⭐️ `NEXTAUTH_URL` 배포환경 `.env`에 추가 (해결방법)⭐️
-  Vercel 배포할 때 환경 변수 필수로 설정해야한다. (500 Error 발생)

2. Apple Token 생성 비동기 처리 순서 
-  토큰을 생성한 후 바로 반환
```
// 애플 토큰 생성 함수
const getAppleToken = async () => {
  const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_PRIVATE_KEY}\n-----END PRIVATE KEY-----`;
  return await new SignJWT({})
    .setAudience('https://appleid.apple.com')
    .setIssuer(process.env.APPLE_TEAM_ID!)
    .setIssuedAt(new Date().getTime() / 1000)
    .setExpirationTime(new Date().getTime() / 1000 + 3600 * 2)
    .setSubject(process.env.APPLE_ID!)
    .setProtectedHeader({
      alg: 'ES256',
      kid: process.env.APPLE_KEY_ID,
    })
    .sign(createPrivateKey(key));
};
```

-  토큰을 생성한 후, 콘솔에 출력한 다음 반환 
```
// 애플 토큰 생성 함수
const getAppleToken = async () => {
  const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_PRIVATE_KEY}\n-----END PRIVATE KEY-----`;
  const token = await new SignJWT({})
    .setAudience('https://appleid.apple.com')
    .setIssuer(process.env.APPLE_TEAM_ID!)
    .setIssuedAt(new Date().getTime() / 1000)
    .setExpirationTime(new Date().getTime() / 1000 + 3600 * 2)
    .setSubject(process.env.APPLE_ID!)
    .setProtectedHeader({
      alg: 'ES256',
      kid: process.env.APPLE_KEY_ID,
    })
    .sign(createPrivateKey(key));

  console.log('Generated Apple Client Secret:', token); // 토큰 로그 출력
  return token;
};
```
