### PR TITLE
Feat/#54: BottomSheet 공통 컴포넌트 분리

### DIFF
--- a/components/Common/BottomSheet/BottomSheet.styles.ts
+++ b/components/Common/BottomSheet/BottomSheet.styles.ts
@@ -1,0 +1,89 @@
+import colors from '@/styles/color/palette';
+import { motion } from 'framer-motion';
+import styled from 'styled-components';
+
+export const BackgroundOverlay = styled(motion.div)`
+  position: fixed;
+  top: 0;
+  left: 50%;
+
+  width: 100%;
+  min-width: 340px;
+  max-width: 430px;
+  height: 100vh;
+
+  margin: 0 auto;
+
+  z-index: 999;
+  background: rgba(0, 0, 0, 0.5);
+`;
+
+export const BottomSheetWrapper = styled(motion.div)<{ $isExpand: boolean }>`
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+
+  bottom: 0;
+  left: 50%;
+
+  width: 100%;
+  min-width: 340px;
+  max-width: 430px;
+  margin: 0 auto;
+
+  height: ${({ $isExpand }) => ($isExpand ? '100vh' : '50vh')};
+
+  background: ${colors.etc.white};
+  border-radius: ${({ $isExpand }) => ($isExpand ? '0' : '4px 4px 0px 0px')};
+  padding: 12px 0 21px 0;
+
+  will-change: transform;
+  z-index: 999;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 0 16px 16px 16px;
+`;
+
+export const HeaderWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export const HeaderHandler = styled.div`
+  width: 40px;
+  height: 4px;
+  border-radius: 100px;
+  background: ${colors.gray[50]};
+  margin: 0 0 8px 0;
+`;
+
+export const ContentHeader = styled.div`
+  color: #000;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 150%;
+`;
+
+export const ContentContainer = styled.div<{ $isExpand: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  height: ${({ $isExpand }) => ($isExpand ? `88vh` : '40vh')};
+  gap: 12px;
+  font-size: 14px;
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/components/Common/BottomSheet/BottomSheet.tsx
+++ b/components/Common/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,43 @@
+import useBottomSheet from '@/hooks/bottomSheet/useBottomSheet';
+import {
+  BackgroundOverlay,
+  BottomSheetWrapper,
+  ContentWrapper,
+  HeaderHandler,
+  HeaderWrapper,
+} from './BottomSheet.styles';
+
+interface BottomSheetProps {
+  children: React.ReactNode;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const BottomSheet = ({ children, setIsOpen }: BottomSheetProps) => {
+  const { isExpand, onDragEnd } = useBottomSheet({
+    setIsOpen,
+  });
+
+  return (
+    <>
+      <BackgroundOverlay initial={{ x: '-50%' }} />
+      <BottomSheetWrapper
+        $isExpand={isExpand}
+        initial={{ x: '-50%' }}
+        animate={{ y: '0%' }}
+        exit={{ y: '100%' }}
+        transition={{ type: 'tween' }}
+        drag="y"
+        dragConstraints={{ top: 0, bottom: 0 }}
+        dragElastic={0.2}
+        onDragEnd={onDragEnd}
+      >
+        <HeaderWrapper>
+          <HeaderHandler />
+        </HeaderWrapper>
+        <ContentWrapper>{children}</ContentWrapper>
+      </BottomSheetWrapper>
+    </>
+  );
+};
+
+export default BottomSheet;

--- a/components/Common/BottomSheet/LocationListBottomSheet.styles.ts
+++ b/components/Common/BottomSheet/LocationListBottomSheet.styles.ts
@@ -1,70 +1,4 @@
-import colors from '@/styles/color/palette';
-import { motion } from 'framer-motion';
 import styled from 'styled-components';
-
-export const BackgroundOverlay = styled(motion.div)`
-  position: fixed;
-  top: 0;
-  left: 50%;
-
-  width: 100%;
-  min-width: 340px;
-  max-width: 430px;
-  height: 100vh;
-
-  margin: 0 auto;
-
-  z-index: 999;
-  background: rgba(0, 0, 0, 0.5);
-`;
-
-export const BottomSheet = styled(motion.div)<{ $isExpand: boolean }>`
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-
-  bottom: 0;
-  left: 50%;
-
-  width: 100%;
-  min-width: 340px;
-  max-width: 430px;
-  margin: 0 auto;
-
-  height: ${({ $isExpand }) => ($isExpand ? '100vh' : '50vh')};
-
-  background: ${colors.etc.white};
-  border-radius: ${({ $isExpand }) => ($isExpand ? '0' : '4px 4px 0px 0px')};
-  padding: 12px 0 21px 0;
-
-  will-change: transform;
-  z-index: 999;
-`;
-
-export const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 0 16px 16px 16px;
-`;
-
-export const HeaderWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
-`;
-
-export const HeaderHandler = styled.div`
-  width: 40px;
-  height: 4px;
-  border-radius: 100px;
-  background: ${colors.gray[50]};
-  margin: 0 0 8px 0;
-`;
 
 export const ContentHeader = styled.div`
   color: #000;
@@ -74,12 +8,12 @@ export const ContentHeader = styled.div`
   line-height: 150%;
 `;
 
-export const ContentContainer = styled.div<{ $isExpand: boolean }>`
+export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
-  height: ${({ $isExpand }) => ($isExpand ? `88vh` : '40vh')};
+  height: 88vh; //TODO 데이터 존재할 때 높이 확인 필요
   gap: 12px;
   font-size: 14px;
   overflow-y: scroll;
@@ -88,12 +22,12 @@ export const ContentContainer = styled.div<{ $isExpand: boolean }>`
   }
 `;
 
-export const NoContentText = styled.div<{ $isExpand: boolean }>`
+export const NoContentText = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: ${({ $isExpand }) => ($isExpand ? `88vh` : '40vh')};
+  height: 40vh;
   font-size: 14px;
 `;
 

--- a/components/Common/BottomSheet/LocationListBottomSheet.tsx
+++ b/components/Common/BottomSheet/LocationListBottomSheet.tsx
@@ -1,12 +1,6 @@
-import { useState } from 'react';
 import {
-  BackgroundOverlay,
-  BottomSheet,
   ContentHeader,
   ContentContainer,
-  ContentWrapper,
-  HeaderWrapper,
-  HeaderHandler,
   NoContentText,
   IntersectionObserverArea,
   LoadingText,
@@ -14,6 +8,7 @@ import {
 import LocationList from '@/components/Layout/Home/LocationList/LocationList';
 import useGetInfiniteLocationList from '@/hooks/locationList/useGetInfiniteLocationList';
 import useIntersectionObserver from '@/hooks/locationList/useIntersectionObserver';
+import BottomSheet from './BottomSheet';
 
 interface LocationListBottomSheetProps {
   setLocationListVisible: React.Dispatch<React.SetStateAction<boolean>>;
@@ -22,9 +17,6 @@ interface LocationListBottomSheetProps {
 const LocationListBottomSheet = ({
   setLocationListVisible,
 }: LocationListBottomSheetProps) => {
-  // bottomSheet 최대 영역 확인하는 로직
-  const [isExpand, setIsExpand] = useState(false);
-
   // 무한 스크롤 로직
   const {
     locationList,
@@ -42,51 +34,23 @@ const LocationListBottomSheet = ({
 
   return (
     <>
-      <>
-        <BackgroundOverlay initial={{ x: '-50%' }} />
-        <BottomSheet
-          $isExpand={isExpand}
-          initial={{ x: '-50%' }}
-          animate={{ y: '0%' }}
-          exit={{ y: '100%' }}
-          transition={{ type: 'tween' }}
-          drag="y"
-          dragConstraints={{ top: 0, bottom: 0 }}
-          dragElastic={0.2}
-          onDragEnd={(event, info) => {
-            const isScrollToBottom = info.delta.y > 5 || info.offset.y > 150;
-            if (isScrollToBottom) {
-              // 스크롤 아래로 내리는 경우
-              setIsExpand(false);
-              setLocationListVisible(false);
-            } else {
-              // 스크롤 위로 올리는 경우
-              setIsExpand(true);
-            }
-          }}
-        >
-          <HeaderWrapper>
-            <HeaderHandler />
-          </HeaderWrapper>
-          <ContentWrapper>
-            <ContentHeader>올린 장소 ({totalCount})</ContentHeader>
-            <ContentContainer $isExpand={isExpand}>
-              {locationList.map((location, index) => (
-                <LocationList key={`key+${index}`} location={location} />
-              ))}
-              {isLoading && <LoadingText>장소를 불러오는중...🔍</LoadingText>}
-              {!isLoading && !isInitialLoad && isLoadMore && (
-                <IntersectionObserverArea ref={targetElementRef} />
-              )}
-              {!isInitialLoad && locationList.length === 0 && (
-                <NoContentText $isExpand={isExpand}>
-                  올린 장소가 없습니다. 장소를 등록해주세요! 😊
-                </NoContentText>
-              )}
-            </ContentContainer>
-          </ContentWrapper>
-        </BottomSheet>
-      </>
+      <BottomSheet setIsOpen={setLocationListVisible}>
+        <ContentHeader>올린 장소 ({totalCount})</ContentHeader>
+        <ContentContainer>
+          {locationList.map((location, index) => (
+            <LocationList key={`key+${index}`} location={location} />
+          ))}
+          {isLoading && <LoadingText>장소를 불러오는중...🔍</LoadingText>}
+          {!isLoading && !isInitialLoad && isLoadMore && (
+            <IntersectionObserverArea ref={targetElementRef} />
+          )}
+          {!isInitialLoad && locationList.length === 0 && (
+            <NoContentText>
+              올린 장소가 없습니다. 장소를 등록해주세요! 😊
+            </NoContentText>
+          )}
+        </ContentContainer>
+      </BottomSheet>
     </>
   );
 };

--- a/hooks/bottomSheet/useBottomSheet.ts
+++ b/hooks/bottomSheet/useBottomSheet.ts
@@ -1,0 +1,31 @@
+import { PanInfo } from 'framer-motion';
+import { useState } from 'react';
+
+interface useBottomSheetProps {
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const useBottomSheet = ({ setIsOpen }: useBottomSheetProps) => {
+  const [isExpand, setIsExpand] = useState(false);
+
+  /**
+   * bottomSheet dragEnd 이벤트
+   */
+  const onDragEnd = (
+    event: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo
+  ) => {
+    const isScrollToBottom = info.delta.y > 5 || info.offset.y > 150;
+    if (isScrollToBottom) {
+      // 스크롤 아래로 내리는 경우
+      setIsExpand(false);
+      setIsOpen(false);
+    } else {
+      // 스크롤 위로 올리는 경우
+      setIsExpand(true);
+    }
+  };
+  return { isExpand, onDragEnd };
+};
+
+export default useBottomSheet;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#54 

## 📝 작업 내용
- BottomSheet를 공통 컴포넌트로 분리했습니다.
  - BottomSheet 컴포넌트 생성
  - BottomSheet 관련 로직 커스텀 훅으로 분리
- 올린 장소 조회 BottomSheet에 BottomSheet Component 적용했습니다.  

## 💬 리뷰 요구사항
### 활용법
- BottomSheet를 사용하는 곳이 많아져서, 공통 컴포넌트로 분리했습니다.
- BottomSheet의 props
  - children: BottomSheet를 사용할 JSX
  - setIsOpen: BottomSheet를 열고 닫는 형태를 외부에서 관리
```tsx
interface BottomSheetProps {
  children: React.ReactNode;
  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
}
```

### 개선 사항
- 기존 BottomSheet에 존재하는 애니메이션적인 문제는 아직 고치지 못했습니다.
- API 연결 후, 작업을 완료하면 진행하도록 하겠습니다. 😓 