### PR TITLE
Feat/#56 로그인 refresh token 설정 및 middleware 설정

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -87,7 +87,8 @@ const authOptions: NextAuthOptions = {
 
   session: {
     strategy: 'jwt', //JWT 기반 인증
-    maxAge: 24 * 60 * 60, // 24시간
+    maxAge: 24 * 60 * 60, // 24시간 - 세션 총 유효기간
+    updateAge: 10 * 60 * 60, // 1시간  - 세션 업데이트 주기
   },
   secret: process.env.NEXTAUTH_SECRET, //JWT 암호화 키 설정
   callbacks: {

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -113,18 +113,16 @@ const authOptions: NextAuthOptions = {
 
       // 토큰이 만료되지 않았으면 현재 토큰 반환
       const tokenExpires = token.accessTokenExpires as number;
-      if (tokenExpires && Date.now() < tokenExpires) {
-        return token;
+      // 만료 10분 전부터 갱신 시도
+      if (tokenExpires && Date.now() + 10 * 60 * 1000 > tokenExpires) {
+        console.log('토큰 만료 10분 전, 갱신:', {
+          현재시간: new Date(Date.now()).toISOString(),
+          만료시간: new Date(tokenExpires).toISOString(),
+        });
+        return refreshAccessToken(token);
       }
 
-      // 토큰이 만료되었으면 갱신
-      return refreshAccessToken(token);
-    },
-
-    async session({ session, token }) {
-      session.accessToken = token.accessToken as string | undefined;
-      session.error = token.error as string | undefined;
-      return session;
+      return token;
     },
   },
 };

--- a/lib/auth/refreshToken.ts
+++ b/lib/auth/refreshToken.ts
@@ -1,0 +1,54 @@
+import axios from 'axios';
+import { JWT } from 'next-auth/jwt';
+
+interface Token extends JWT {
+  [key: string]: unknown;
+  provider?: string;
+  refreshToken?: string;
+  accessToken?: string;
+  accessTokenExpires?: number;
+  error?: string;
+}
+
+export async function refreshAccessToken(token: Token): Promise<Token> {
+  try {
+    console.log('토큰 갱신 시작:', { provider: token.provider });
+
+    if (!token.refreshToken) throw new Error('refresh token이 없습니다.');
+
+    const url =
+      token.provider === 'kakao'
+        ? 'https://kauth.kakao.com/oauth/token'
+        : 'https://appleid.apple.com/auth/token';
+
+    console.log('토큰 갱신 요청 URL:', url);
+
+    const response = await axios.post(url, {
+      grant_type: 'refresh_token',
+      client_id: process.env[`${token.provider?.toUpperCase()}_CLIENT_ID`],
+      refresh_token: token.refreshToken,
+    });
+
+    console.log('토큰 갱신 성공:', {
+      expires_in: response.data.expires_in,
+      hasAccessToken: !!response.data.access_token,
+      hasRefreshToken: !!response.data.refresh_token,
+    });
+
+    return {
+      ...token,
+      accessToken: response.data.access_token,
+      accessTokenExpires: Date.now() + response.data.expires_in * 1000,
+      refreshToken: response.data.refresh_token ?? token.refreshToken,
+    };
+  } catch (error) {
+    console.error('토큰 갱신 실패:', {
+      provider: token.provider,
+      error: error instanceof Error ? error.message : error,
+    });
+    return {
+      ...token,
+      error: 'RefreshAccessTokenError',
+    };
+  }
+}

--- a/lib/types/next-auth.d.ts
+++ b/lib/types/next-auth.d.ts
@@ -3,10 +3,22 @@ import 'next-auth';
 declare module 'next-auth' {
   interface Session {
     accessToken?: string;
+    error?: string;
   }
 
   interface JWT {
+    [key: string]: unknown;
     accessToken?: string;
     refreshToken?: string;
+    accessTokenExpires?: number;
+    provider?: string;
+    error?: string;
+  }
+
+  interface Account {
+    expires_in: number;
+    access_token: string;
+    refresh_token: string;
+    provider: string;
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,6 +31,9 @@ export default withAuth(
     callbacks: {
       authorized: ({ token }) => !!token,
     },
+    pages: {
+      signIn: '/login',
+    },
   }
 );
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,6 +40,6 @@ export const config = {
     // API 경로에 대해서만 적용
     '/api/:path*',
     // auth 관련 경로는 제외
-    '/((?!api/auth|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api/auth|_next/static|_next/image|favicon.ico|login|$).*)',
   ],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { withAuth, NextRequestWithAuth } from 'next-auth/middleware';
+
+export default withAuth(
+  async function middleware(request: NextRequestWithAuth) {
+    console.log('middleware 실행', {
+      path: request.nextUrl.pathname,
+      token: request.nextauth.token,
+    });
+
+    // 토큰이 없거나 만료된 경우
+    if (!request.nextauth.token) {
+      return NextResponse.json(
+        { error: '인증되지 않은 요청입니다.' },
+        { status: 401 }
+      );
+    }
+
+    // 토큰의 만료 시간 확인
+    const tokenExpires = request.nextauth.token.accessTokenExpires as number;
+    if (tokenExpires && Date.now() > tokenExpires) {
+      return NextResponse.json(
+        { error: '토큰이 만료되었습니다.' },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.next();
+  },
+  {
+    callbacks: {
+      authorized: ({ token }) => !!token,
+    },
+  }
+);
+
+// 미들웨어를 적용할 경로 설정
+export const config = {
+  matcher: [
+    // API 경로에 대해서만 적용
+    '/api/:path*',
+    // auth 관련 경로는 제외
+    '/((?!api/auth|_next/static|_next/image|favicon.ico).*)',
+  ],
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#56 

## 📝 작업 내용
### 1. refreshToken을 사용해 만료된 accessToken을 갱신
- 토큰 갱신 로직을`lib/auth/refreshToken.ts`로 분리하여 사용하고자 합니다.
- 세션 최대 수명 : 24시간, 만료 10분 전 refreshToken 재생성

### 2. middleware.ts 설정
`middleware.ts`를 구성하여 비로그인 유저(`accessToken` X)의 접근을 제한하였습니다.

**⭐️ 인증 없이 접근 가능 페이지 ⭐️** 
- `/` (메인 페이지)
- `/login` (로그인 페이지)
- `/api/auth/*` (인증 관련 API)
- `/_next/*` (Next.js 시스템 파일들)

이 외의 페이지는 `accessToken`이 존재하지않을 경우 `/login`으로 리다이렉트 되도록 설정하였습니다.

### 📸 스크린샷
![middlewareSetting](https://github.com/user-attachments/assets/902b4b32-e4f7-4eb6-9310-4cf0a8b60042)

## 💬 리뷰 요구사항
