### PR TITLE
Feat: 타입 정의 이동 및 세션 관리 추가

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -125,6 +125,17 @@ const authOptions: NextAuthOptions = {
 
       return token;
     },
+    async session({ session, token }) {
+      // JWT 토큰의 정보를 세션에 포함
+      return {
+        ...session,
+        user: {
+          ...session.user,
+          accessToken: token.accessToken,
+          // refreshToken은 보안을 위해 클라이언트에 전달 X
+        },
+      };
+    },
   },
 };
 

--- a/lib/auth/refreshToken.ts
+++ b/lib/auth/refreshToken.ts
@@ -1,14 +1,5 @@
 import axios from 'axios';
-import { JWT } from 'next-auth/jwt';
-
-interface Token extends JWT {
-  [key: string]: unknown;
-  provider?: string;
-  refreshToken?: string;
-  accessToken?: string;
-  accessTokenExpires?: number;
-  error?: string;
-}
+import type { Token } from 'next-auth';
 
 export async function refreshAccessToken(token: Token): Promise<Token> {
   try {

--- a/lib/types/next-auth.d.ts
+++ b/lib/types/next-auth.d.ts
@@ -21,4 +21,13 @@ declare module 'next-auth' {
     refresh_token: string;
     provider: string;
   }
+
+  interface Token extends JWT {
+    [key: string]: unknown;
+    provider?: string;
+    refreshToken?: string;
+    accessToken?: string;
+    accessTokenExpires?: number;
+    error?: string;
+  }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#58 

## 📝 작업 내용
### 1. 누락된 session 콜백 추가
```    
async session({ session, token }) {
      // JWT 토큰의 정보를 세션에 포함
      return {
        ...session,
        user: {
          ...session.user,
          accessToken: token.accessToken,
          // refreshToken은 보안을 위해 클라이언트에 전달 X
        }
      }
    }
```
- refreshToken은 항상 서버 측 token에서만 관리
- accessToken은 필요에 따라 클라이언트의 session에도 전달 가능

### 2. `refreshToken.ts` interface 정의  ➡️ `next-auth.d.ts`로 통일화
interface 정의와 관련된 부분을 `next-auth.d.ts`에 모두 정의하도록 수정하였습니다.

## 💬 리뷰 요구사항
지난 PR에서 수정해야할 부분을 해당 PR에서 수정했습니다.
추가로 제가 놓친 부분이나 반영해야할 부분이 이전 PR에서 존재했다면 이곳에서 반영하여 수정할 예정입니다.
