### PR TITLE
Feat/#61 소셜로그인 백엔드 연동 및 사용자 상태관리

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -4,9 +4,26 @@ import AppleProvider from 'next-auth/providers/apple';
 import { createPrivateKey } from 'crypto';
 import { SignJWT } from 'jose';
 import { refreshAccessToken } from '@/lib/auth/refreshToken';
+import type {
+  AppleRequest,
+  AppleUserInfo,
+  KakaoProfile,
+} from '@/lib/types/next-auth';
+
+// 전역 변수로 이동
+let appleFirstInfo: AppleUserInfo | null = null;
 
 // 애플 토큰 생성 함수
-const getAppleToken = async () => {
+const getAppleToken = async (req?: AppleRequest) => {
+  if (
+    req?.url?.includes('callback/apple') &&
+    req?.method === 'POST' &&
+    req.body?.user
+  ) {
+    appleFirstInfo = JSON.parse(req.body.user);
+    console.log('애플 최초 가입 정보:', appleFirstInfo);
+  }
+
   const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_PRIVATE_KEY}\n-----END PRIVATE KEY-----`;
   const token = await new SignJWT({})
     .setAudience('https://appleid.apple.com')
@@ -19,8 +36,6 @@ const getAppleToken = async () => {
       kid: process.env.APPLE_KEY_ID,
     })
     .sign(createPrivateKey(key));
-
-  // console.log('Generated Apple Client Secret:', token); // 토큰 로그 출력
   return token;
 };
 
@@ -92,15 +107,51 @@ const authOptions: NextAuthOptions = {
   },
   secret: process.env.NEXTAUTH_SECRET, //JWT 암호화 키 설정
   callbacks: {
-    async signIn({ user, account, profile, email, credentials }) {
-      console.log('로그인 시도 데이터:', {
-        user,
-        account,
-        profile,
-        email,
-        credentials,
-      });
-      return true;
+    async signIn({ user, account, profile }) {
+      try {
+        const platformType = account?.provider.toUpperCase();
+
+        // 제공자별 닉네임 처리
+        let nickname;
+        if (platformType === 'KAKAO') {
+          // 카카오는 항상 nickname을 제공
+          nickname = (profile as KakaoProfile)?.nickname;
+        } else if (platformType === 'APPLE') {
+          if (appleFirstInfo?.name) {
+            // 애플 최초 로그인시에만 이름 정보 사용
+            nickname = `${appleFirstInfo.name.firstName}${appleFirstInfo.name.lastName || ''}`;
+          }
+          // 이름 정보가 없는 경우 nickname은 undefined로 전송
+        }
+
+        const response = await fetch(`${process.env.API_URL}/api/auth/login`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            nickname, // 카카오: nickname 전달, 애플: 최초에만 이름 전달, 이후엔 undefined
+            email: user.email,
+            platformType,
+            platformId: user.id,
+            profileImageUrl: user.image || '',
+            accessToken: account?.access_token,
+            refreshToken: account?.refresh_token,
+          }),
+        });
+
+        if (!response.ok) {
+          console.error('DB 저장 실패:', await response.text());
+          return false;
+        }
+
+        const data = await response.json();
+        console.log('DB 저장 성공:', data);
+        return true;
+      } catch (error) {
+        console.error('로그인 처리 중 에러:', error);
+        return false;
+      }
     },
 
     async jwt({ token, account }) {

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -124,21 +124,24 @@ const authOptions: NextAuthOptions = {
           // 이름 정보가 없는 경우 nickname은 undefined로 전송
         }
 
-        const response = await fetch(`${process.env.API_URL}/api/auth/login`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            nickname, // 카카오: nickname 전달, 애플: 최초에만 이름 전달, 이후엔 undefined
-            email: user.email,
-            platformType,
-            platformId: user.id,
-            profileImageUrl: user.image || '',
-            accessToken: account?.access_token,
-            refreshToken: account?.refresh_token,
-          }),
-        });
+        const response = await fetch(
+          `${process.env.API_URL}/api/user-service/users/save`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              nickname, // 카카오: nickname 전달, 애플: 최초에만 이름 전달, 이후엔 undefined
+              email: user.email,
+              platformType,
+              platformId: user.id,
+              profileImageUrl: user.image || '',
+              accessToken: account?.access_token,
+              refreshToken: account?.refresh_token,
+            }),
+          }
+        );
 
         if (!response.ok) {
           console.error('DB 저장 실패:', await response.text());

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -136,7 +136,6 @@ const authOptions: NextAuthOptions = {
               email: user.email,
               platformType,
               platformId: user.id,
-              profileImageUrl: user.image || '',
               accessToken: account?.access_token,
               refreshToken: account?.refresh_token,
             }),

--- a/lib/types/next-auth.d.ts
+++ b/lib/types/next-auth.d.ts
@@ -30,4 +30,38 @@ declare module 'next-auth' {
     accessTokenExpires?: number;
     error?: string;
   }
+
+  interface User {
+    id: string;
+    email?: string | null;
+    name?: string | null;
+    image?: string | null;
+  }
+
+  interface Profile extends KakaoProfile {
+    sub?: string;
+    email?: string;
+    name?: string;
+    image?: string;
+  }
+}
+
+export interface AppleRequest {
+  url?: string;
+  method?: string;
+  body?: {
+    user?: string;
+  };
+}
+
+export interface AppleUserInfo {
+  name?: {
+    firstName: string;
+    lastName?: string;
+  };
+}
+
+export interface KakaoProfile {
+  nickname?: string;
+  [key: string]: unknown;
 }

--- a/stores/useUserStore.ts
+++ b/stores/useUserStore.ts
@@ -1,16 +1,16 @@
 import { create } from 'zustand';
 
 interface UserState {
-  email: string;
+  userId: number;
   nickname: string;
-  setEmail: (email: string) => void;
+  setUserId: (userId: number) => void;
   setNickname: (nickname: string) => void;
 }
 
 const useUserStore = create<UserState>((set) => ({
-  email: '',
+  userId: 0,
   nickname: '',
-  setEmail: (email: string) => set({ email }),
+  setUserId: (userId: number) => set({ userId }),
   setNickname: (nickname: string) => set({ nickname }),
 }));
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#61 

## 📝 작업 내용
**1. 소셜 로그인 성공 시 플랫폼 별 데이터 수집**
- Apple : 최초 로그인 1회 시에만 name 값 제공
- KaKao : 로그인 시 NickName 값 상시 제공

**2. 백엔드 API로 POST 요청**
```
const response = await fetch(
  `${process.env.API_URL}/api/user-service/users/save`,
  {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
    },
    body: JSON.stringify({
      nickname,
      email: user.email,
      platformType,
      platformId: user.id,
      profileImageUrl: user.image || '',
      accessToken: account?.access_token,
      refreshToken: account?.refresh_token,
    }),
  }
);
```
**3. `useUserStore.ts` 상태관리 값 변경(userId:number, nickname:string)**

## 💬 리뷰 요구사항
- PR Approve 후에 배포 환경에서 각각 로그인 후에 배포 로그 확인 및 DB 저장 확인을 진행 할 예정입니다.
- swagger에서 server 주소가 `https://urdego.site` 로 되어있는데 `API_URL`도 기존 `https://urdego.com`에서 변경해야하는 부분일까요?
- 이전 hotfix 작업 후에 branch 변경을 까먹어서 hotfix 브랜치에서 작업하게되었는데 사용하지 않은 브랜치는 추후 삭제하겠습니다.. 😱