### PR TITLE
Feat/#76 kakao login type 구조 변경

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -115,7 +115,7 @@ const authOptions: NextAuthOptions = {
         let nickname;
         if (platformType === 'KAKAO') {
           // 카카오는 항상 nickname을 제공
-          nickname = (profile as KakaoProfile)?.nickname;
+          nickname = (profile as KakaoProfile)?.properties?.nickname;
         } else if (platformType === 'APPLE') {
           if (appleFirstInfo?.name) {
             // 애플 최초 로그인시에만 이름 정보 사용

--- a/lib/types/next-auth.d.ts
+++ b/lib/types/next-auth.d.ts
@@ -37,13 +37,6 @@ declare module 'next-auth' {
     name?: string | null;
     image?: string | null;
   }
-
-  interface Profile extends KakaoProfile {
-    sub?: string;
-    email?: string;
-    name?: string;
-    image?: string;
-  }
 }
 
 export interface AppleRequest {
@@ -60,8 +53,21 @@ export interface AppleUserInfo {
     lastName?: string;
   };
 }
-
-export interface KakaoProfile {
-  nickname?: string;
-  [key: string]: unknown;
+interface KakaoProfile {
+  id: number;
+  connected_at: string;
+  properties: {
+    nickname: string;
+  };
+  kakao_account: {
+    profile_nickname_needs_agreement: boolean;
+    profile: {
+      nickname: string;
+    };
+    has_email: boolean;
+    email_needs_agreement: boolean;
+    is_email_valid: boolean;
+    is_email_verified: boolean;
+    email: string;
+  };
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#76 

## 📝 작업 내용
1. KakaoProfile 타입 실제 리턴 구조로 재정의
```
interface KakaoProfile {
  id: number;
  connected_at: string;
  properties: {
    nickname: string;
  };
  kakao_account: {
    profile_nickname_needs_agreement: boolean;
    profile: any;
    has_email: boolean;
    email_needs_agreement: boolean;
    is_email_valid: boolean;
    is_email_verified: boolean;
    email: string;
  };
}
```
`properties.nickname`으로 값이 전달되는 것 같아 수정 후 테스트해보겠습니다.
