### PR TITLE
Fix: undefined일 시 빈 문자열 리턴

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -112,23 +112,23 @@ const authOptions: NextAuthOptions = {
 
         if (platformType === 'KAKAO') {
           requestData = {
-            nickname: user.name || null,
-            email: user.email || null,
+            nickname: user.name || '',
+            email: user.email || '',
             platformType: platformType,
-            platformId: user.id || null,
-            accessToken: account?.access_token || null,
-            refreshToken: account?.refresh_token || null,
+            platformId: user.id || '',
+            accessToken: account?.access_token || '',
+            refreshToken: account?.refresh_token || '',
           };
         } else if (platformType === 'APPLE') {
           requestData = {
             nickname: appleFirstInfo?.name
               ? `${appleFirstInfo.name.firstName}${appleFirstInfo.name.lastName || ''}`
-              : null,
-            email: profile?.email || null,
+              : '',
+            email: profile?.email || '',
             platformType: platformType,
-            platformId: profile?.id || null,
-            accessToken: account?.access_token || null,
-            refreshToken: account?.refresh_token || null,
+            platformId: profile?.sub || '',
+            accessToken: account?.access_token || '',
+            refreshToken: account?.refresh_token || '',
           };
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#76 

## 📝 작업 내용
**해당 이슈는 클라이언트에서 로그인은 성공했지만 백엔드에 Data 전송 시 에러가 발생하여 NextAuth의 Error페이지로 리다이렉트 되는 것으로 추정하고있습니다.**
로그인 성공 및 데이터 값이 존재할 경우와 존재하지 않을 경우 모두 데이터 타입을 맞추어 재테스트를 진행합니다.

