### PR TITLE
Feat/#81 소셜로그인 Callback Issue 해결

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -116,19 +116,16 @@ const authOptions: NextAuthOptions = {
             email: user.email || '',
             platformType: platformType,
             platformId: user.id || '',
-            accessToken: account?.access_token || '',
-            refreshToken: account?.refresh_token || '',
           };
         } else if (platformType === 'APPLE') {
+          const emailId = profile?.email?.split('@')[0];
           requestData = {
             nickname: appleFirstInfo?.name
               ? `${appleFirstInfo.name.firstName}${appleFirstInfo.name.lastName || ''}`
-              : '',
+              : emailId,
             email: profile?.email || '',
             platformType: platformType,
             platformId: profile?.sub || '',
-            accessToken: account?.access_token || '',
-            refreshToken: account?.refresh_token || '',
           };
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#81 

## 📝 작업 내용
> 백엔드 전송 성공 여부 상관없이 임시로 Callback True 설정하려 하였으나, 원인을 찾아 해결하였기에 수정없이 진행하였습니다.

**1. 카카오 유저 정보 및 Nickname 전송 테스트 (성공)**
<img width="277" alt="스크린샷 2025-01-22 오후 3 57 10" src="https://github.com/user-attachments/assets/c3e9d6cb-f999-4e33-af82-3f9e4bb6322f" />

**2. 애플 유저 정보 및 NickName 추출 및 전송 테스트 (실패) ➡️ 대안으로 `undefined`일 시 애플 아이디를 닉네임으로 설정**
<img width="534" alt="스크린샷 2025-01-22 오후 3 56 49" src="https://github.com/user-attachments/assets/2d2bd848-dd18-4d6c-aaed-94ff6f2ba2e6" />


## 💬 리뷰 요구사항

- 백엔드 로직 수정 후 DB에 잘 저장되어, Error 페이지로 CallBack 되는 현상은 BE 로직 수정 이후에 더 이상 발생하지 않아
애플 로그인 닉네임 설정하는 부분만 애플 아이디로 저장될 수 있도록 수정한 후 배포테스트 진행 할 예정입니다.
---
테스트완료했어요 !~
<img width="514" alt="스크린샷 2025-01-22 오후 4 17 46" src="https://github.com/user-attachments/assets/962093d2-e169-4d87-845c-4f61537ff4d8" />
