### PR TITLE
Feature/#83 회원탈퇴 로직 구현 및 테스트 완료

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -12,17 +12,8 @@ import useUserStore from '@/stores/useUserStore';
 
 const LoginPage = () => {
   const { data: session } = useSession();
-  const { setUserId, setNickname } = useUserStore();
   const userId = useUserStore((state) => state.userId);
   const nickname = useUserStore((state) => state.nickname);
-
-  // 세션 데이터로 store 업데이트
-  useEffect(() => {
-    if (session?.user?.userId) {
-      setUserId(session.user.userId);
-      setNickname(session.user.nickname ?? '');
-    }
-  }, [session, setUserId, setNickname]);
 
   // store 값 변화 감지
   useEffect(() => {

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { signIn, signOut, useSession } from 'next-auth/react';
 import { LoginWrapper } from './Login.styles';
 import LoginThumbnail from '@/styles/Icon/Login/LoginThumbnail.svg';
@@ -7,10 +8,26 @@ import Image from 'next/image';
 import { LogoContainer, LoginTitle, SocialButton } from './Login.styles';
 import KakaoLogin from '@/styles/Icon/Login/KakaoLogin.svg';
 import AppleLogin from '@/styles/Icon/Login/AppleLogin.svg';
+import useUserStore from '@/stores/useUserStore';
 
 const LoginPage = () => {
   const { data: session } = useSession();
-  console.log(session?.accessToken); // accessToken
+  const { setUserId, setNickname } = useUserStore();
+  const userId = useUserStore((state) => state.userId);
+  const nickname = useUserStore((state) => state.nickname);
+
+  // 세션 데이터로 store 업데이트
+  useEffect(() => {
+    if (session?.user?.userId) {
+      setUserId(session.user.userId);
+      setNickname(session.user.nickname ?? '');
+    }
+  }, [session, setUserId, setNickname]);
+
+  // store 값 변화 감지
+  useEffect(() => {
+    console.log('로그인 페이지 - 유저 스토어 정보:', { userId, nickname });
+  }, [userId, nickname]);
 
   return (
     <LoginWrapper>

--- a/app/(nav)/myPage/accountCencellation/page.tsx
+++ b/app/(nav)/myPage/accountCencellation/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import TopBar from '@/components/Common/TopBar/TopBar';
 import Button from '@common/Button/Button';
 import CheckboxOption from '@common/CheckboxOption/CheckboxOption';
@@ -19,6 +19,14 @@ import {
 import { signOut } from 'next-auth/react';
 
 const AccountCancellation = () => {
+  // store에서 값 가져오기
+  const userId = useUserStore((state) => state.userId);
+  const nickname = useUserStore((state) => state.nickname);
+
+  useEffect(() => {
+    console.log('탈퇴 페이지 - 유저 스토어 정보:', { userId, nickname });
+  }, [userId, nickname]);
+
   const [reasons, setReasons] = useState({
     gameDislike: false,
     inconvenience: false,
@@ -53,7 +61,6 @@ const AccountCancellation = () => {
       reasons.inconvenience ||
       (reasons.other && isValid)); // 🔥 10자 이상 입력해야 버튼 활성화
 
-  const { userId } = useUserStore();
   const handleWithdraw = async () => {
     try {
       const response = await fetch('/api/auth/withdraw', {
@@ -62,7 +69,7 @@ const AccountCancellation = () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          userId,
+          userId, // store에서 가져온 userId 사용
           withDrawReason: otherReason,
         }),
       });

--- a/app/(nav)/myPage/accountCencellation/page.tsx
+++ b/app/(nav)/myPage/accountCencellation/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react';
 import TopBar from '@/components/Common/TopBar/TopBar';
 import Button from '@common/Button/Button';
 import CheckboxOption from '@common/CheckboxOption/CheckboxOption';
+import useUserStore from '@/stores/useUserStore';
 import {
   SessionWrapper,
   SubTitle,
@@ -15,6 +16,7 @@ import {
   Separator,
   CharCount,
 } from '@/app/(nav)/myPage/accountCencellation/accountCencellation.styles';
+import { signOut } from 'next-auth/react';
 
 const AccountCancellation = () => {
   const [reasons, setReasons] = useState({
@@ -50,6 +52,32 @@ const AccountCancellation = () => {
     (reasons.gameDislike ||
       reasons.inconvenience ||
       (reasons.other && isValid)); // 🔥 10자 이상 입력해야 버튼 활성화
+
+  const { userId } = useUserStore();
+  const handleWithdraw = async () => {
+    try {
+      const response = await fetch('/api/auth/withdraw', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userId,
+          withDrawReason: otherReason,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('회원 탈퇴 실패');
+      }
+
+      // 2. 탈퇴 성공 시 로그아웃 처리
+      signOut({ callbackUrl: '/' });
+    } catch (error) {
+      console.error('회원 탈퇴 중 에러:', error);
+      // 에러 처리 (TODO: 토스트 메시지)
+    }
+  };
 
   return (
     <>
@@ -120,9 +148,7 @@ const AccountCancellation = () => {
           label="회원탈퇴"
           buttonType={canSubmit ? 'purple' : 'gray'}
           disabled={!canSubmit}
-          onClick={() => {
-            console.log('탈퇴 이유:', reasons, '기타 사유:', otherReason);
-          }}
+          onClick={handleWithdraw}
         />
       </Footer>
     </>

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -129,8 +129,6 @@ const authOptions: NextAuthOptions = {
           };
         }
 
-        console.log('전송할 데이터:', requestData); // 디버깅용
-
         const response = await fetch(
           `${process.env.API_URL}/api/user-service/users/save`,
           {
@@ -148,7 +146,8 @@ const authOptions: NextAuthOptions = {
         }
 
         const data = await response.json();
-        console.log('DB 저장 성공:', data);
+        user.userId = data.userId;
+        user.nickname = data.nickname;
         return true;
       } catch (error) {
         console.error('로그인 처리 중 에러:', error);
@@ -156,13 +155,19 @@ const authOptions: NextAuthOptions = {
       }
     },
 
-    async jwt({ token, account }) {
+    async jwt({ token, account, user }) {
       // 초기 로그인 시 토큰 설정
       if (account) {
         token.accessToken = account.access_token;
         token.refreshToken = account.refresh_token;
         token.accessTokenExpires = Date.now() + account.expires_in * 1000;
         token.provider = account.provider;
+      }
+
+      // user 데이터가 있으면 token에 추가
+      if (user) {
+        token.userId = user.userId;
+        token.nickname = user.nickname;
       }
 
       // 토큰이 만료되지 않았으면 현재 토큰 반환
@@ -185,7 +190,8 @@ const authOptions: NextAuthOptions = {
         user: {
           ...session.user,
           accessToken: token.accessToken,
-          // refreshToken은 보안을 위해 클라이언트에 전달 X
+          userId: token.userId,
+          nickname: token.nickname,
         },
       };
     },

--- a/app/api/auth/withdraw/route.ts
+++ b/app/api/auth/withdraw/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
     }
 
     // 요청 바디에서 탈퇴 사유 가져오기
-    const { userId, withDrawReason } = await req.json();
+    const { userId, withDrawalReason } = await req.json();
 
     // 1. 소셜 로그인 연결 해제
     if (token.provider === 'kakao') {
@@ -38,12 +38,12 @@ export async function POST(req: NextRequest) {
     const withdrawResponse = await fetch(
       `${process.env.API_URL}/api/user-service/users/${userId}`,
       {
-        method: 'POST',
+        method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token.accessToken}`,
         },
-        body: JSON.stringify({ withDrawReason }),
+        body: JSON.stringify({ withDrawalReason }),
       }
     );
 

--- a/app/api/auth/withdraw/route.ts
+++ b/app/api/auth/withdraw/route.ts
@@ -1,0 +1,59 @@
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
+const KAKAO_UNLINK_URI = 'https://kapi.kakao.com/v1/user/unlink';
+const APPLE_UNLINK_URI = 'https://appleid.apple.com/auth/revoke';
+
+export async function POST(req: NextRequest) {
+  try {
+    // 1. 현재 세션의 토큰 가져오기
+    const token = await getToken({ req });
+    if (!token) {
+      return NextResponse.json({ error: '인증 필요' }, { status: 401 });
+    }
+
+    // 요청 바디에서 탈퇴 사유 가져오기
+    const { userId, withDrawReason } = await req.json();
+
+    // 1. 소셜 로그인 연결 해제
+    if (token.provider === 'kakao') {
+      const kakaoResponse = await fetch(KAKAO_UNLINK_URI, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token.accessToken}` },
+      });
+      if (!kakaoResponse.ok) {
+        throw new Error('카카오 연결 해제 실패');
+      }
+    } else if (token.provider === 'apple') {
+      const appleResponse = await fetch(APPLE_UNLINK_URI, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token.accessToken}` },
+      });
+      if (!appleResponse.ok) {
+        throw new Error('애플 연결 해제 실패');
+      }
+    }
+
+    // 2. 백엔드 회원 정보 삭제
+    const withdrawResponse = await fetch(
+      `${process.env.API_URL}/api/user-service/users/${userId}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token.accessToken}`,
+        },
+        body: JSON.stringify({ withDrawReason }),
+      }
+    );
+
+    if (!withdrawResponse.ok) {
+      throw new Error('회원 정보 삭제 실패');
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('회원 탈퇴 처리 중 에러:', error);
+    return NextResponse.json({ error: '회원 탈퇴 처리 실패' }, { status: 500 });
+  }
+}

--- a/components/Layout/Login/SessionWrapper.tsx
+++ b/components/Layout/Login/SessionWrapper.tsx
@@ -1,8 +1,30 @@
 'use client';
-import { SessionProvider } from 'next-auth/react';
+import { SessionProvider, useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+import useUserStore from '@/stores/useUserStore';
+
+// 세션 데이터로 store 업데이트하는 컴포넌트
+function SessionStoreUpdater() {
+  const { data: session } = useSession();
+  const { setUserId, setNickname } = useUserStore();
+
+  useEffect(() => {
+    if (session?.user?.userId) {
+      setUserId(session.user.userId);
+      setNickname(session.user.nickname ?? '');
+    }
+  }, [session, setUserId, setNickname]);
+
+  return null;
+}
 
 const SessionWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <SessionStoreUpdater />
+      {children}
+    </SessionProvider>
+  );
 };
 
 export default SessionWrapper;

--- a/lib/types/next-auth.d.ts
+++ b/lib/types/next-auth.d.ts
@@ -4,6 +4,11 @@ declare module 'next-auth' {
   interface Session {
     accessToken?: string;
     error?: string;
+    user: {
+      userId?: number;
+      nickname?: string;
+      email?: string | null;
+    };
   }
 
   interface JWT {
@@ -36,6 +41,8 @@ declare module 'next-auth' {
     email?: string | null;
     name?: string | null;
     image?: string | null;
+    userId?: number;
+    nickname?: string;
   }
 
   interface Profile extends KakaoProfile {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#83 

## 📝 작업 내용
**1. 로그인 성공 시 `response` 값 `session` 데이터로 업데이트**
다음과 같이 페이지에서 `nickname`, `userId` 값 사용하시면 될 것 같습니다.

```
  const { setUserId, setNickname } = useUserStore();
  const userId = useUserStore((state) => state.userId);
  const nickname = useUserStore((state) => state.nickname);
```

**2. `withdrawReasons` 탈퇴 사유 객체로 변경**

**3. 회원 탈퇴 기능 구현**
- 1. 세션 토큰 가져오기
- 2. 소셜 로그인 연결 해제 
(앱 출시 시 소셜 연결 해제까지 진행해야한다하여 둘 다 연결해제까지 진행하였습니다.)
```
const KAKAO_UNLINK_URI = 'https://kapi.kakao.com/v1/user/unlink';
const APPLE_UNLINK_URI = 'https://appleid.apple.com/auth/revoke';
```
 

## 💬 리뷰 요구사항
로그인 성공 시 `/home`으로 리다이렉트 되도록 되어있었지만 갑자기 `/`로 리다이렉트 되고 있는 현상이 있네요..😥
로그인 성공한 것이니 해결할 동안은 일단 url로 이동해주세요오..
