### PR TITLE
Feat/#63: 컨텐츠 조회 최적화

### DIFF
--- a/components/Common/BottomSheet/LocationListBottomSheet.styles.ts
+++ b/components/Common/BottomSheet/LocationListBottomSheet.styles.ts
@@ -6,6 +6,7 @@ export const ContentHeader = styled.div`
   font-style: normal;
   font-weight: 700;
   line-height: 150%;
+  padding: 8px 0;
 `;
 
 export const ContentContainer = styled.div`

--- a/components/Common/BottomSheet/LocationListBottomSheet.tsx
+++ b/components/Common/BottomSheet/LocationListBottomSheet.tsx
@@ -38,7 +38,7 @@ const LocationListBottomSheet = ({
         <ContentHeader>올린 장소 ({totalCount})</ContentHeader>
         <ContentContainer>
           {locationList.map((location, index) => (
-            <LocationList key={`key+${index}`} location={location} />
+            <LocationList key={`list+${index}`} location={location} />
           ))}
           {isLoading && <LoadingText>장소를 불러오는중...🔍</LoadingText>}
           {!isLoading && !isInitialLoad && isLoadMore && (

--- a/components/Common/BottomSheet/LocationListBottomSheet.tsx
+++ b/components/Common/BottomSheet/LocationListBottomSheet.tsx
@@ -9,6 +9,7 @@ import LocationList from '@/components/Layout/Home/LocationList/LocationList';
 import useGetInfiniteLocationList from '@/hooks/locationList/useGetInfiniteLocationList';
 import useIntersectionObserver from '@/hooks/locationList/useIntersectionObserver';
 import BottomSheet from './BottomSheet';
+import DotLoadingSpinner from '../LoadingSpinner/DotLoadingSpinner';
 
 interface LocationListBottomSheetProps {
   setLocationListVisible: React.Dispatch<React.SetStateAction<boolean>>;
@@ -34,7 +35,7 @@ const LocationListBottomSheet = ({
           {locationList.map((location, index) => (
             <LocationList key={`key+${index}`} location={location} />
           ))}
-          {isLoading && <LoadingText>장소를 불러오는중...🔍</LoadingText>}
+          {isLoading && <DotLoadingSpinner />}
           {!isLoading && isLoadMore && (
             <IntersectionObserverArea ref={targetElementRef} />
           )}

--- a/components/Common/BottomSheet/LocationListBottomSheet.tsx
+++ b/components/Common/BottomSheet/LocationListBottomSheet.tsx
@@ -18,17 +18,11 @@ const LocationListBottomSheet = ({
   setLocationListVisible,
 }: LocationListBottomSheetProps) => {
   // 무한 스크롤 로직
-  const {
-    locationList,
-    totalCount,
-    isInitialLoad,
-    isLoading,
-    isLoadMore,
-    loadMore,
-  } = useGetInfiniteLocationList();
+  const { locationList, totalCount, isLoading, isLoadMore, fetchLocationList } =
+    useGetInfiniteLocationList();
   const targetElementRef = useIntersectionObserver({
     handleIntersect: () => {
-      loadMore();
+      fetchLocationList();
     },
   });
 
@@ -38,13 +32,13 @@ const LocationListBottomSheet = ({
         <ContentHeader>올린 장소 ({totalCount})</ContentHeader>
         <ContentContainer>
           {locationList.map((location, index) => (
-            <LocationList key={`list+${index}`} location={location} />
+            <LocationList key={`key+${index}`} location={location} />
           ))}
           {isLoading && <LoadingText>장소를 불러오는중...🔍</LoadingText>}
-          {!isLoading && !isInitialLoad && isLoadMore && (
+          {!isLoading && isLoadMore && (
             <IntersectionObserverArea ref={targetElementRef} />
           )}
-          {!isInitialLoad && locationList.length === 0 && (
+          {locationList.length === 0 && (
             <NoContentText>
               올린 장소가 없습니다. 장소를 등록해주세요! 😊
             </NoContentText>

--- a/components/Common/BottomSheet/LocationListBottomSheet.tsx
+++ b/components/Common/BottomSheet/LocationListBottomSheet.tsx
@@ -3,7 +3,6 @@ import {
   ContentContainer,
   NoContentText,
   IntersectionObserverArea,
-  LoadingText,
 } from './LocationListBottomSheet.styles';
 import LocationList from '@/components/Layout/Home/LocationList/LocationList';
 import useGetInfiniteLocationList from '@/hooks/locationList/useGetInfiniteLocationList';

--- a/components/Common/BottomSheet/LocationListBottomSheet.tsx
+++ b/components/Common/BottomSheet/LocationListBottomSheet.tsx
@@ -38,7 +38,7 @@ const LocationListBottomSheet = ({
           {!isLoading && isLoadMore && (
             <IntersectionObserverArea ref={targetElementRef} />
           )}
-          {locationList.length === 0 && (
+          {!isLoadMore && locationList.length === 0 && (
             <NoContentText>
               올린 장소가 없습니다. 장소를 등록해주세요! 😊
             </NoContentText>

--- a/components/Common/LoadingSpinner/DotLoadingSpinner.styles.ts
+++ b/components/Common/LoadingSpinner/DotLoadingSpinner.styles.ts
@@ -23,8 +23,8 @@ export const DotContainer = styled.div`
 `;
 
 export const Dot = styled.div`
-  width: 13px;
-  height: 13px;
+  width: 11px;
+  height: 11px;
   background-color: ${colors.gray[90]};
   border-radius: 50%;
   animation: ${fadeInOut} 1.5s infinite ease-in-out;

--- a/components/Common/LoadingSpinner/DotLoadingSpinner.styles.ts
+++ b/components/Common/LoadingSpinner/DotLoadingSpinner.styles.ts
@@ -1,0 +1,38 @@
+import colors from '@/styles/color/palette';
+import styled, { keyframes } from 'styled-components';
+
+const fadeInOut = keyframes`
+  0% {
+    transform: scale(0);
+  }
+  50%{
+    transform: scale(1.0);
+  }
+  100% {
+    transform: scale(0);
+  }
+`;
+
+export const DotContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 15%;
+  height: 100%;
+  margin: auto;
+`;
+
+export const Dot = styled.div`
+  width: 13px;
+  height: 13px;
+  background-color: ${colors.gray[90]};
+  border-radius: 50%;
+  animation: ${fadeInOut} 1.5s infinite ease-in-out;
+
+  &:nth-child(2) {
+    animation-delay: 0.16s;
+  }
+  &:nth-child(3) {
+    animation-delay: 0.32s;
+  }
+`;

--- a/components/Common/LoadingSpinner/DotLoadingSpinner.tsx
+++ b/components/Common/LoadingSpinner/DotLoadingSpinner.tsx
@@ -1,0 +1,13 @@
+import { DotContainer, Dot } from './DotLoadingSpinner.styles';
+
+const DotLoadingSpinner = () => {
+  return (
+    <DotContainer>
+      <Dot />
+      <Dot />
+      <Dot />
+    </DotContainer>
+  );
+};
+
+export default DotLoadingSpinner;

--- a/components/Layout/Home/LocationList/LocationList.tsx
+++ b/components/Layout/Home/LocationList/LocationList.tsx
@@ -26,7 +26,7 @@ const LocationList = ({ location }: LocationListProps) => {
           fill
           style={{ objectFit: 'cover' }}
           sizes="(max-width: 430px) 100vw"
-          onLoadingComplete={() => setIsLoading(false)}
+          onLoad={() => setIsLoading(false)}
         />
       </LocationImageContainer>
       {isLoading ? (

--- a/components/Layout/Home/LocationList/LocationList.tsx
+++ b/components/Layout/Home/LocationList/LocationList.tsx
@@ -5,28 +5,41 @@ import {
   LocationContainer,
   LocationTitle,
   LocationDetail,
+  SkeletonLocationContainer,
 } from './LocationList.styles';
+import Skeleton from '@/components/Common/Skeleton/Skeleton';
+import { useState } from 'react';
 
 interface LocationListProps {
   location: { contentName: string; address: string; url: string };
 }
 
 const LocationList = ({ location }: LocationListProps) => {
+  const [isLoading, setIsLoading] = useState(true);
   return (
     <LocationListWrapper>
       <LocationImageContainer>
+        {isLoading ? <Skeleton width={48} height={48} /> : null}
         <Image
           src={location?.url}
           alt="Location Image"
           fill
           style={{ objectFit: 'cover' }}
           sizes="(max-width: 430px) 100vw"
+          onLoadingComplete={() => setIsLoading(false)}
         />
       </LocationImageContainer>
-      <LocationContainer>
-        <LocationTitle>{location?.contentName}</LocationTitle>
-        <LocationDetail>{location?.address}</LocationDetail>
-      </LocationContainer>
+      {isLoading ? (
+        <SkeletonLocationContainer>
+          <Skeleton width={330} height={20} />
+          <Skeleton width={330} height={20} />
+        </SkeletonLocationContainer>
+      ) : (
+        <LocationContainer>
+          <LocationTitle>{location?.contentName}</LocationTitle>
+          <LocationDetail>{location?.address}</LocationDetail>
+        </LocationContainer>
+      )}
     </LocationListWrapper>
   );
 };

--- a/components/Layout/PlaceRegister/PlacePreview.tsx
+++ b/components/Layout/PlaceRegister/PlacePreview.tsx
@@ -39,12 +39,12 @@ const PlacePreview = ({ index }: PlacePreviewProps) => {
         (partPreviewLoading) => partPreviewLoading === true
       )
         ? isPreviewLoading[index].map((_, index) => (
-            <PreviewImage key={index}>
+            <PreviewImage key={`item${index}`}>
               <Skeleton width={60} height={60} />
             </PreviewImage>
           ))
         : placeList[index].previewFile.map((file, previewIndex) => (
-            <PreviewImage key={previewIndex}>
+            <PreviewImage key={`item${previewIndex}`}>
               <PreviewImageRemoveButton
                 onClick={() => handlePartFileRemove(previewIndex)}
               >

--- a/hooks/locationList/useGetInfiniteLocationList.ts
+++ b/hooks/locationList/useGetInfiniteLocationList.ts
@@ -1,5 +1,5 @@
 import useUserStore from '@/stores/useUserStore';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 interface Location {
   contentId: number;

--- a/hooks/locationList/useGetInfiniteLocationList.ts
+++ b/hooks/locationList/useGetInfiniteLocationList.ts
@@ -2,6 +2,7 @@ import useUserStore from '@/stores/useUserStore';
 import { useEffect, useState } from 'react';
 
 interface Location {
+  contentId: number;
   contentName: string;
   address: string;
   url: string;

--- a/hooks/locationList/useGetInfiniteLocationList.ts
+++ b/hooks/locationList/useGetInfiniteLocationList.ts
@@ -59,6 +59,7 @@ const useGetInfiniteLocationList = () => {
       if (!response.ok) {
         throw new Error('데이터를 가져오는 것에 실패했습니다!');
       }
+
       const data: GetLocationListResponse = await response.json();
       console.log(data);
       if (data) {
@@ -73,7 +74,6 @@ const useGetInfiniteLocationList = () => {
       }
     } catch (error) {
       console.error(`올린 장소 불러오기에서 실패한 에러: ${error}`);
-      setIsLoading(false);
       setIsLoadMore(false);
     } finally {
       setIsLoading(false);

--- a/hooks/locationList/useGetInfiniteLocationList.ts
+++ b/hooks/locationList/useGetInfiniteLocationList.ts
@@ -48,7 +48,7 @@ const useGetInfiniteLocationList = () => {
     setIsLoading(true);
 
     const params = new URLSearchParams();
-    params.append('limit', (10).toString());
+    params.append('limit', (16).toString());
     if (cursorIdx) {
       params.append('cursorIdx', cursorIdx.toString());
     }

--- a/hooks/locationList/useGetInfiniteLocationList.ts
+++ b/hooks/locationList/useGetInfiniteLocationList.ts
@@ -26,22 +26,16 @@ interface GetLocationListResponse {
 }
 
 const useGetInfiniteLocationList = () => {
+  // 서버로부터 받아오는 정보
   const [locationList, setLocationList] = useState<Location[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [cursorIdx, setCursorIdx] = useState<number | null>(null);
+
+  // 무한 스크롤 관련 정보
   const [isLoadMore, setIsLoadMore] = useState(true);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
+
   // const { userId } = useUserStore(); //TODO: 사용하도록 변경
-
-  useEffect(() => {
-    const initialFetchLocationList = async () => {
-      await fetchLocationList();
-      setIsInitialLoad(false);
-    };
-
-    initialFetchLocationList();
-  }, []);
 
   const fetchLocationList = async () => {
     const userId = 2; //! test를 위한 용도
@@ -80,19 +74,12 @@ const useGetInfiniteLocationList = () => {
     }
   };
 
-  const loadMore = async () => {
-    if (!isLoadMore) return;
-
-    await fetchLocationList();
-  };
-
   return {
     locationList,
     totalCount,
-    isInitialLoad,
     isLoading,
     isLoadMore,
-    loadMore,
+    fetchLocationList,
   };
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#68 

## 📝 작업 내용
- 컨텐츠 조회시, 이미지 및 텍스트 불러올 때 `Skeleton UI` 적용
- 컨텐츠 조회시, 서버로부터 데이터 요청할 때 `원형 도트 확대 로딩 스피너` 적용
- 무한 스크롤 훅에서 contentId 저장하도록 설정 추가
- 무한 스크롤 훅에서 반복되는 로직 삭제

### 📸 스크린샷
- Skeleton UI 적용
- 원형 도프 확대 로딩 스피너 적용 
![250123](https://github.com/user-attachments/assets/730dbe5a-2895-4858-bde9-783b0ae66d5d)

## 💬 리뷰 요구사항
### 무한 스크롤 훅(useGetInfiniteLocationList.ts) 변경사항
- isInitialLoad 변수 삭제
  - 서버로부터 정보 가져오는 첫 단계를 확인하는 변수인 isInitialLoad를 삭제했습니다. 
  - 대신, 기존의 isLoadMore와 isLoading으로 무한 스크롤의 상태를 확인하고 반영했습니다. 
- loadMore 함수 삭제
  - 서버로부터 정보 가져오는 로직을 실행하는 loadMore 함수를 삭제했습니다. 
  - fetchLocationList 함수를 직접 할당하는 방식을 사용했습니다.
### 로딩 스피너 적용
원형 도트 확장 버전의 로딩 스피너를 구현했습니다. 무한 스크롤 관련 로직을 사용하시는 분은 활용하시면 됩니다!