### PR TITLE
Feat/#89: 미리보기 이미지 수 우선적으로 증가 구현 및 메타 데이터 추출 개선

### DIFF
--- a/hooks/placeRegister/useRegisterFiles.ts
+++ b/hooks/placeRegister/useRegisterFiles.ts
@@ -17,10 +17,10 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
   const MAX_MEMORY = 30 * 1024 * 1024; // 30MB
 
   const handleFilesUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFileList = validateUserUploadFile(e.target.files);
-    if (!selectedFileList) return;
-
     try {
+      const selectedFileList = validateUserUploadFile(e.target.files);
+      if (!selectedFileList) return;
+
       setPreviewLoading({
         locationIndex: index,
         newPreviewLoading: new Array(selectedFileList.length).fill(true),
@@ -31,27 +31,8 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
         new Array(selectedFileList.length).fill([])
       );
 
-      if (isOverMemory(selectedFileList)) {
-        toast.error('업로드 가능한 용량을 초과했어요');
-        throw new Error('업로드 가능한 용량을 초과했어요');
-      }
-      if (!selectedFileList.every(isImageFile)) {
-        toast.error('이미지만 업로드가 가능해요');
-        throw new Error('이미지만 업로드가 가능해요');
-      }
-
-      // 파일 메타 데이터 추출
-      const isMeta = await exportMetadata(selectedFileList);
-      if (!isMeta) {
-        toast('위치 서비스를 활성화하시면, 자동으로 위치를 추가할 수 있어요!', {
-          icon: '👍',
-        });
-      }
-
-      // 파일 등록: 파일 크기 최적화
+      await exportMetadata(selectedFileList);
       const compressedFileList = await compressFile(selectedFileList);
-
-      // 파일 등록: 미리보기 용도
       const previewURLs = await Promise.all(
         compressedFileList.map(readFileAsDataURL)
       );
@@ -86,7 +67,18 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
     }
 
     // 파일 등록: 최대 개수 제한 설정
-    return Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
+    const selectedFileList = Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
+
+    if (isOverMemory(selectedFileList)) {
+      toast.error('업로드 가능한 용량을 초과했어요');
+      throw new Error('업로드 가능한 용량을 초과했어요');
+    }
+    if (!selectedFileList.every(isImageFile)) {
+      toast.error('이미지만 업로드가 가능해요');
+      throw new Error('이미지만 업로드가 가능해요');
+    }
+
+    return selectedFileList;
   };
 
   // 용량 제한 로직
@@ -126,10 +118,11 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
         index,
         latLng: { lat: gps.latitude, lng: gps.longitude },
       });
-
-      return true;
+      return;
     }
-    return false;
+    toast('위치 서비스를 활성화하시면, 자동으로 위치를 추가할 수 있어요!', {
+      icon: '👍',
+    });
   };
 
   // 이미지 압축 로직

--- a/hooks/placeRegister/useRegisterFiles.ts
+++ b/hooks/placeRegister/useRegisterFiles.ts
@@ -20,32 +20,32 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
     // 파일 불러오는 로직
     const fileList = e.target.files;
 
-    if (!fileList || fileList?.length === 0) {
-      return;
-    }
-    if (fileList.length > MAX_CONTENT_COUNT) {
-      toast('최대 3개의 사진만 업로드가 가능해요', {
-        icon: '😱',
-      });
-    }
-
-    const selectedFileList = Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
-
-    if (isOverMemory(selectedFileList)) {
-      toast.error('업로드 가능한 용량을 초과했어요');
-      return;
-    }
-    if (!selectedFileList.every(isImageFile)) {
-      toast.error('이미지만 업로드가 가능해요');
-      return;
-    }
-
-    setPreviewLoading({
-      locationIndex: index,
-      newPreviewLoading: new Array(selectedFileList.length).fill(true),
-    });
-
     try {
+      if (!fileList || fileList?.length === 0) {
+        return;
+      }
+      if (fileList.length > MAX_CONTENT_COUNT) {
+        toast('최대 3개의 사진만 업로드가 가능해요', {
+          icon: '😱',
+        });
+      }
+
+      const selectedFileList = Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
+
+      if (isOverMemory(selectedFileList)) {
+        toast.error('업로드 가능한 용량을 초과했어요');
+        return;
+      }
+      if (!selectedFileList.every(isImageFile)) {
+        toast.error('이미지만 업로드가 가능해요');
+        return;
+      }
+
+      setPreviewLoading({
+        locationIndex: index,
+        newPreviewLoading: new Array(selectedFileList.length).fill(true),
+      });
+
       const isMeta = await exportMetadata(selectedFileList);
       if (!isMeta) {
         toast('위치 서비스를 활성화하시면, 자동으로 위치를 추가할 수 있어요!', {
@@ -54,16 +54,12 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
       }
 
       const compressedFileList = await compressFile(selectedFileList);
-      console.log(selectedFileList);
-      console.log(compressedFileList);
-      previewFile(selectedFileList);
-      previewFile(compressedFileList);
 
       storeFile(compressedFileList);
       storePreviewFile(compressedFileList);
       setPreviewLoading({
         locationIndex: index,
-        newPreviewLoading: new Array(selectedFileList.length).fill(false),
+        newPreviewLoading: new Array(compressedFileList.length).fill(false),
       });
     } catch (error) {
       console.log(error);

--- a/hooks/placeRegister/useRegisterFiles.ts
+++ b/hooks/placeRegister/useRegisterFiles.ts
@@ -20,31 +20,35 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
     // 파일 불러오는 로직
     const fileList = e.target.files;
 
+    if (!fileList || fileList?.length === 0) {
+      return;
+    }
+    if (fileList.length > MAX_CONTENT_COUNT) {
+      toast('최대 3개의 사진만 업로드가 가능해요', {
+        icon: '😱',
+      });
+    }
+
+    const selectedFileList = Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
     try {
-      if (!fileList || fileList?.length === 0) {
-        return;
-      }
-      if (fileList.length > MAX_CONTENT_COUNT) {
-        toast('최대 3개의 사진만 업로드가 가능해요', {
-          icon: '😱',
-        });
-      }
-
-      const selectedFileList = Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
-
-      if (isOverMemory(selectedFileList)) {
-        toast.error('업로드 가능한 용량을 초과했어요');
-        return;
-      }
-      if (!selectedFileList.every(isImageFile)) {
-        toast.error('이미지만 업로드가 가능해요');
-        return;
-      }
-
       setPreviewLoading({
         locationIndex: index,
         newPreviewLoading: new Array(selectedFileList.length).fill(true),
       });
+      setPlaceInput(
+        index,
+        'previewFile',
+        new Array(selectedFileList.length).fill([])
+      );
+
+      if (isOverMemory(selectedFileList)) {
+        toast.error('업로드 가능한 용량을 초과했어요');
+        throw new Error('업로드 가능한 용량을 초과했어요');
+      }
+      if (!selectedFileList.every(isImageFile)) {
+        toast.error('이미지만 업로드가 가능해요');
+        throw new Error('이미지만 업로드가 가능해요');
+      }
 
       const isMeta = await exportMetadata(selectedFileList);
       if (!isMeta) {
@@ -57,17 +61,13 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
 
       storeFile(compressedFileList);
       storePreviewFile(compressedFileList);
-      setPreviewLoading({
-        locationIndex: index,
-        newPreviewLoading: new Array(compressedFileList.length).fill(false),
-      });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
-      console.log(error);
+      setPlaceInput(index, 'previewFile', []);
       setPreviewLoading({
         locationIndex: index,
         newPreviewLoading: [],
       });
-      toast.error('사진 등록에 실패했어요');
     }
   };
 
@@ -178,6 +178,10 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
 
     Promise.all(previewPromises).then((previewURLs) => {
       setPlaceInput(index, 'previewFile', previewURLs);
+      setPreviewLoading({
+        locationIndex: index,
+        newPreviewLoading: new Array(selectedFileList.length).fill(false),
+      });
     });
   };
 

--- a/hooks/placeRegister/useRegisterFiles.ts
+++ b/hooks/placeRegister/useRegisterFiles.ts
@@ -18,21 +18,17 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
 
   const handleFilesUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     try {
-      const selectedFileList = validateUserUploadFile(e.target.files);
-      if (!selectedFileList) return;
+      const fileList = validateUserUploadFile(e.target.files);
+      if (!fileList) return;
 
       setPreviewLoading({
         locationIndex: index,
-        newPreviewLoading: new Array(selectedFileList.length).fill(true),
+        newPreviewLoading: new Array(fileList.length).fill(true),
       });
-      setPlaceInput(
-        index,
-        'previewFile',
-        new Array(selectedFileList.length).fill([])
-      );
+      setPlaceInput(index, 'previewFile', new Array(fileList.length).fill([]));
 
-      await exportMetadata(selectedFileList);
-      const compressedFileList = await compressFile(selectedFileList);
+      await exportMetadata(fileList);
+      const compressedFileList = await compressFile(fileList);
       const previewURLs = await Promise.all(
         compressedFileList.map(readFileAsDataURL)
       );
@@ -41,7 +37,7 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
       setPlaceInput(index, 'previewFile', previewURLs);
       setPreviewLoading({
         locationIndex: index,
-        newPreviewLoading: new Array(selectedFileList.length).fill(false),
+        newPreviewLoading: new Array(compressedFileList.length).fill(false),
       });
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/hooks/placeRegister/useRegisterFiles.ts
+++ b/hooks/placeRegister/useRegisterFiles.ts
@@ -17,19 +17,9 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
   const MAX_MEMORY = 30 * 1024 * 1024; // 30MB
 
   const handleFilesUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    // 파일 불러오는 로직
-    const fileList = e.target.files;
+    const selectedFileList = validateUserUploadFile(e.target.files);
+    if (!selectedFileList) return;
 
-    if (!fileList || fileList?.length === 0) {
-      return;
-    }
-    if (fileList.length > MAX_CONTENT_COUNT) {
-      toast('최대 3개의 사진만 업로드가 가능해요', {
-        icon: '😱',
-      });
-    }
-
-    const selectedFileList = Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
     try {
       setPreviewLoading({
         locationIndex: index,
@@ -50,6 +40,7 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
         throw new Error('이미지만 업로드가 가능해요');
       }
 
+      // 파일 메타 데이터 추출
       const isMeta = await exportMetadata(selectedFileList);
       if (!isMeta) {
         toast('위치 서비스를 활성화하시면, 자동으로 위치를 추가할 수 있어요!', {
@@ -57,14 +48,16 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
         });
       }
 
+      // 파일 등록: 파일 크기 최적화
       const compressedFileList = await compressFile(selectedFileList);
+
+      // 파일 등록: 미리보기 용도
       const previewURLs = await Promise.all(
         compressedFileList.map(readFileAsDataURL)
       );
 
       setPlaceInput(index, 'file', compressedFileList);
       setPlaceInput(index, 'previewFile', previewURLs);
-
       setPreviewLoading({
         locationIndex: index,
         newPreviewLoading: new Array(selectedFileList.length).fill(false),
@@ -78,6 +71,22 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
         newPreviewLoading: [],
       });
     }
+  };
+
+  const validateUserUploadFile = (userUploadFileList: FileList | null) => {
+    const fileList = userUploadFileList;
+
+    if (!fileList || fileList?.length === 0) {
+      return;
+    }
+    if (fileList.length > MAX_CONTENT_COUNT) {
+      toast('최대 3개의 사진만 업로드가 가능해요', {
+        icon: '😱',
+      });
+    }
+
+    // 파일 등록: 최대 개수 제한 설정
+    return Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
   };
 
   // 용량 제한 로직

--- a/hooks/placeRegister/useRegisterFiles.ts
+++ b/hooks/placeRegister/useRegisterFiles.ts
@@ -58,9 +58,18 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
       }
 
       const compressedFileList = await compressFile(selectedFileList);
+      const previewURLs = await Promise.all(
+        compressedFileList.map(readFileAsDataURL)
+      );
 
-      storeFile(compressedFileList);
-      storePreviewFile(compressedFileList);
+      setPlaceInput(index, 'file', compressedFileList);
+      setPlaceInput(index, 'previewFile', previewURLs);
+
+      setPreviewLoading({
+        locationIndex: index,
+        newPreviewLoading: new Array(selectedFileList.length).fill(false),
+      });
+
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
       setPlaceInput(index, 'previewFile', []);
@@ -158,30 +167,15 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
     });
   };
 
-  // 서버에 전송할 파일 저장 로직
-  const storeFile = (selectedFileList: File[]) => {
-    setPlaceInput(index, 'file', selectedFileList);
-  };
-
-  // 미리보기 파일 저장 로직
-  const storePreviewFile = (selectedFileList: File[]) => {
-    const previewPromises = selectedFileList.map((file) => {
-      return new Promise<string>((resolve) => {
-        const fileReader = new FileReader();
-        fileReader.onload = () => {
-          const result = fileReader.result;
-          resolve(typeof result === 'string' ? result : '');
-        };
-        fileReader.readAsDataURL(file);
-      });
-    });
-
-    Promise.all(previewPromises).then((previewURLs) => {
-      setPlaceInput(index, 'previewFile', previewURLs);
-      setPreviewLoading({
-        locationIndex: index,
-        newPreviewLoading: new Array(selectedFileList.length).fill(false),
-      });
+  // 기본 파일을 미리보기 파일로 변환하는 로직
+  const readFileAsDataURL = (file: File): Promise<string> => {
+    return new Promise<string>((resolve) => {
+      const fileReader = new FileReader();
+      fileReader.onload = () => {
+        const result = fileReader.result;
+        resolve(typeof result === 'string' ? result : '');
+      };
+      fileReader.readAsDataURL(file);
     });
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#89 

## 📝 작업 내용
### 미리보기 이미지의 수 우선적 증가
#### 기존의 상황
사용자가 이미지를 업로드했을 때, 다음의 과정을 통해 업로드가 완료됩니다.
- 최대 개수 제한 점검
- 용량 초과 점검
- 메타 데이터 추출
- 이미지 압축 및 크기 제한
- 미리보기 제공을 위한 DataURL 생성
- Store에 서버 전송을 위한 이미지, 미리보기를 위한 이미지 저장

6개의 단계를 거쳐서, 저장이 완료되기에 1-2초의 시간이 소요됩니다. 
이때, 스켈레톤을 제공하여 업로드한 이미지가 처리되고 있음을 알리지만 미리보기는 아직 저장이 되지 않아 미리보기 이미지 수가 업데이트되지 않아 화면상에서 모순된 그림을 보입니다.
#### 해결방법
해당 모순을 해결하기 위해 미리보기 이미지 수를 우선적으로 증가한 후, 예외 처리를 확인하는 로직에서 에러가 발생한다면 미리보기 이미지 수를 0으로 감소시키거나 올바르게 저장이 완료되었다면 미리보기 이미지 수를 유지하는 방법으로 UI 구현을 진행했습니다.

#### 적용 전
스켈레톤이 적용되어 업로드가 되고 있음을 나타내고 있지만, 전체 이미지의 수는 변하지 않습니다.
![image](https://github.com/user-attachments/assets/b9008275-bbc3-4274-af33-e72543ae07bc)
#### 적용 후
스켈레톤이 적용되어 업로드가 되고 있음을 나타내고 있고, 전체 이미지의 수도 3/3으로 변했습니다.
![image](https://github.com/user-attachments/assets/31e0272f-fcb9-4ba8-8003-8db2164a901b)

### 메타 데이터 추출 개선
기존의 로직은 사용자가 업로드한 복수의 사진 중 첫 번째 사진의 메타 데이터를 추출하는 로직으로 구성되었습니다.
이번 리팩토링에서 복수의 사진에 존재하는 모든 위경도를 추출한 후, 그 중 첫 번째의 위경도를 기준으로 메타 데이터를 추출하도록 개선했습니다.

## 💬 리뷰 요구사항
메타 데이터를 추출할 때, 최대 3개의 위경도가 존재할 수 있습니다. 이 위경도 중 첫 번째의 것을 추출할지, 여러 위경도의 중간 지점을 추출할지 고민이 됩니다. 조언을 주세요! 😁 (저는 첫 번째 것 추출이 더 올바르다고 생각하여, 해당 로직을 적용한 상태입니다.)
- 첫 번째 것을 추출하는 것
  - 장점: 사용자가 정확한 위치를 추측할 수 있다! 
  - 단점: 사용자가 위치가 다른 이미지를 여러 개 넣는다면, 위치 추적이 불가능하다.
- 중간 지점을 추출하는 것
  - 장점: 위치의 평균값을 사용할 수 있다. 
  - 단점: 엉뚱한 위치가 저장되어, 사진을 보고도 위치를 파악해도 이상한 위치로 표시할 수 있다. 