### PR TITLE
Fix: Lottie 및 GLTFLoader import 에러 해결

### DIFF
--- a/components/Common/LoadingSpinner/LoadingSpinner.tsx
+++ b/components/Common/LoadingSpinner/LoadingSpinner.tsx
@@ -11,7 +11,7 @@ interface LoadingSpinnerComponentProps {
 
 // 동적 import로 LottieComponent 가져오는 방법으로 변경
 const LottieComponent = dynamic(
-  () => import('@/components/Common/Lottie/LottieComponent'),
+  () => import('@components/Common/Lottie/LottieComponent'),
   { ssr: false }
 );
 

--- a/components/Common/LoadingSpinner/LoadingSpinner.tsx
+++ b/components/Common/LoadingSpinner/LoadingSpinner.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { LoadingOverlay } from './LoadingSpinner.style';
-import LottieComponent from '@/components/Common/Lottie/LottieComponent';
 import animationData from '@styles/lottie/loading.json';
 
 interface LoadingSpinnerComponentProps {
   isLocationRegister?: boolean;
 }
+
+// 동적 import로 LottieComponent 가져오는 방법으로 변경
+const LottieComponent = dynamic(
+  () => import('@/components/Common/Lottie/LottieComponent'),
+  { ssr: false }
+);
 
 const LoadingSpinnerComponent: React.FC<LoadingSpinnerComponentProps> = ({
   isLocationRegister = false,

--- a/components/Layout/Home/Character/UserCharacter.tsx
+++ b/components/Layout/Home/Character/UserCharacter.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useRef, useMemo, useEffect } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Environment } from '@react-three/drei';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { useLoader } from '@react-three/fiber';
 import * as THREE from 'three';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "three/examples/jsm/loaders/GLTFLoader": [
+      "./node_modules/three/examples/jsm/loaders/GLTFLoader.js"
+    ],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## 📝 작업 내용
<img width="295" alt="스크린샷 2025-02-02 오전 1 43 13" src="https://github.com/user-attachments/assets/8cbcab91-dfe8-4fa9-b4c5-f633c54c8990" />
1. `LoadingSpinnerComponent`에서 `LottieComponent`를 동적으로 import
- SSR 비활성화

2. `three/examples/jsm/loaders/GLTFLoader` 모듈을 찾을 수 없는 타입스크립트 오류
- `tsconfig.json`에서 모듈 경로를 매핑하여 빌드 시 모듈을 잘 찾을 수 있도록 수정

## 💬 리뷰 요구사항
`lottie` 반영을 담당하신 @minjeongss 님 해당 부분 체크하시고 더블 체크 부탁드려요! 👊🏻
