### PR TITLE
Fix: GLTF 파일명 - public 파일명 URL 경로 문제 해결

### DIFF
--- a/components/Layout/Home/Character/UserCharacter.tsx
+++ b/components/Layout/Home/Character/UserCharacter.tsx
@@ -12,7 +12,10 @@ const Model = ({
   characterKey: string;
   isOpen: boolean;
 }) => {
-  const gltf = useLoader(GLTFLoader, `/Character/${characterKey}.glb`);
+  const gltf = useLoader(
+    GLTFLoader,
+    `/Character/${characterKey.toLowerCase()}.glb`
+  );
   const modelRef = useRef<THREE.Object3D | null>(null);
   const isRotatingRef = useRef(true);
   const rotationSpeed = useRef(0.2);


### PR DESCRIPTION
## 📝 작업 내용
**GLTF 파일명 대소문자로 인한 URL 경로 문제 해결**
| 원인 | public 폴더 구조 |
|----------|----------|
| <img width="264" alt="image" src="https://github.com/user-attachments/assets/d31fb880-6104-4d2b-ab55-d3e5a33909f4" /> | <img width="191" alt="스크린샷 2025-02-02 오전 2 47 06" src="https://github.com/user-attachments/assets/8f8d8e8e-f0e8-415a-9f6d-57384ca09599" /> |

`toLowerCase()`를 활용해서 소문자로 전환한 후 public의 파일명과 동일하게 요청하도록 수정하였습니다.

## 💬 리뷰 요구사항
큰 변경사항은 없고, 배포환경에서 추가 발생하는 이슈들 공유해주시면 해결하겠습니다!