### PR TITLE
Feat/#123 User-service API 변경사항 반영

### DIFF
--- a/app/(nav)/myPage/page.tsx
+++ b/app/(nav)/myPage/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { signOut } from 'next-auth/react';
 import useUserStore from '@/stores/useUserStore';
 import TopBar from '@/components/Common/TopBar/TopBar';
 import {
@@ -53,9 +54,9 @@ const MyPage = () => {
     fetchUserInfo();
   }, [userId]);
 
-  const handleLogout = () => {
-    // 로그아웃 로직
+  const handleLogout = async () => {
     setIsLogoutModalOpen(false);
+    await signOut({ callbackUrl: '/' }); // 로그아웃 후 홈으로 리디렉션
   };
 
   return (

--- a/app/(nav)/myPage/page.tsx
+++ b/app/(nav)/myPage/page.tsx
@@ -22,7 +22,7 @@ const MyPage = () => {
   const [userInfo, setUserInfo] = useState({
     email: '',
     nickname: '',
-    characterType: '',
+    activeCharacter: '',
   });
 
   const userId = useUserStore((state) => state.userId);
@@ -67,7 +67,7 @@ const MyPage = () => {
           <ProfileInfo
             email={userInfo.email}
             nickname={userInfo.nickname}
-            characterType={userInfo.characterType}
+            activeCharacter={userInfo.activeCharacter}
           />
 
           <SmallButtonWrapper>

--- a/app/api/character/route.ts
+++ b/app/api/character/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
     }
 
     const response = await axiosInstance.post(
-      `${API_URL_CONFIG.USER_SERVICE.CHARACTER}/${userId}`,
+      `${API_URL_CONFIG.USER_SERVICE.CHARACTER_CHANGE}/${userId}`,
       { characterName },
       {
         headers: {

--- a/app/api/character/route.ts
+++ b/app/api/character/route.ts
@@ -12,6 +12,7 @@ interface UserResponse {
   activeCharacter: string;
   ownedCharacters: string[];
   exp: number;
+  level: number;
   role: string;
 }
 
@@ -31,8 +32,9 @@ export async function GET(request: NextRequest) {
     );
 
     return NextResponse.json({
-      characterType: response.data.activeCharacter,
+      activeCharacter: response.data.activeCharacter,
       exp: response.data.exp,
+      ownedCharacters: response.data.ownedCharacters,
     });
   } catch (error) {
     console.error('유저 정보 조회 에러:', error);
@@ -55,6 +57,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // 캐릭터 변경 POST 요청
     const response = await axiosInstance.post(
       `${API_URL_CONFIG.USER_SERVICE.CHARACTER_CHANGE}/${userId}`,
       { characterName },

--- a/app/api/character/route.ts
+++ b/app/api/character/route.ts
@@ -35,6 +35,7 @@ export async function GET(request: NextRequest) {
       activeCharacter: response.data.activeCharacter,
       exp: response.data.exp,
       ownedCharacters: response.data.ownedCharacters,
+      level: response.data.level,
     });
   } catch (error) {
     console.error('유저 정보 조회 에러:', error);

--- a/app/api/userInfo/route.ts
+++ b/app/api/userInfo/route.ts
@@ -17,12 +17,15 @@ export async function GET(req: Request) {
       `${API_URL_CONFIG.USER_SERVICE.USERS}/${userId}`
     );
 
-    const { email, nickname, activeCharacter } = response.data;
+    const { email, nickname, activeCharacter, exp, level } = response.data;
+    console.log('유저 정보:', response.data);
 
     return NextResponse.json({
       email,
       nickname,
       activeCharacter,
+      level,
+      exp,
     });
   } catch (error) {
     console.error('Error fetching user data:', error);

--- a/app/api/userInfo/route.ts
+++ b/app/api/userInfo/route.ts
@@ -17,12 +17,12 @@ export async function GET(req: Request) {
       `${API_URL_CONFIG.USER_SERVICE.USERS}/${userId}`
     );
 
-    const { email, nickname, characterType } = response.data;
+    const { email, nickname, activeCharacter } = response.data;
 
     return NextResponse.json({
       email,
       nickname,
-      characterType,
+      activeCharacter,
     });
   } catch (error) {
     console.error('Error fetching user data:', error);

--- a/app/game/[roomId]/[round]/roundRank/page.tsx
+++ b/app/game/[roomId]/[round]/roundRank/page.tsx
@@ -62,7 +62,7 @@ const RoundRank = ({
           nickname: coord.nickname,
           score:
             currentRoundData === 'thisRound' ? coord.score : coord.totalScore,
-          characterType: 'basic',
+          activeCharacter: 'basic',
         }));
 
   const currentRoundDataRef = useRef<'thisRound' | 'totalRound'>(

--- a/components/Layout/Game/RankList.tsx
+++ b/components/Layout/Game/RankList.tsx
@@ -23,7 +23,7 @@ interface RankListProps {
     userId: number;
     nickname: string;
     score: number;
-    characterType: string;
+    activeCharacter: string;
   }[];
   handleToggle: (round: 'thisRound' | 'totalRound') => void;
   initialActiveButton: 'thisRound' | 'totalRound';
@@ -54,42 +54,42 @@ const RankList = ({
         userId: 1,
         nickname: '가가가',
         score: 150,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 2,
         userId: 2,
         nickname: '나나나',
         score: 120,
-        characterType: 'dot',
+        activeCharacter: 'dot',
       },
       {
         rank: 3,
         userId: 3,
         nickname: '다다다',
         score: 100,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 4,
         userId: 4,
         nickname: '라라라',
         score: 70,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 5,
         userId: 5,
         nickname: '마마마',
         score: 50,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 6,
         userId: 6,
         nickname: '바바바',
         score: 10,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
     ],
     totalScore: [
@@ -98,42 +98,42 @@ const RankList = ({
         userId: 1,
         nickname: '가가가',
         score: 420,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 2,
         userId: 2,
         nickname: '나나나',
         score: 380,
-        characterType: 'dot',
+        activeCharacter: 'dot',
       },
       {
         rank: 3,
         userId: 3,
         nickname: '다다다',
         score: 340,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 4,
         userId: 4,
         nickname: '라라라',
         score: 340,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 5,
         userId: 5,
         nickname: '마마마',
         score: 340,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
       {
         rank: 6,
         userId: 6,
         nickname: '바바바',
         score: 340,
-        characterType: 'basic',
+        activeCharacter: 'basic',
       },
     ],
   };
@@ -192,7 +192,7 @@ const RankList = ({
           <UserRow key={user.userId}>
             {getRankDisplay(user.rank)}
             <Image
-              src={`/character/${user.characterType}.png`}
+              src={`/character/${user.activeCharacter}.png`}
               alt={`${user.nickname}의 프로필 이미지`}
               width={32}
               height={32}

--- a/components/Layout/Home/Character/SuccessToast.tsx
+++ b/components/Layout/Home/Character/SuccessToast.tsx
@@ -12,15 +12,15 @@ export const SuccessToast = ({ message }: SuccessToastProps) => {
         style={{
           opacity: t.visible ? 1 : 0,
           transform: `translateY(${t.visible ? 0 : 20}px)`,
-          marginTop: '20px',
+          marginBottom: '280px',
         }}
       >
-        <Message>{message}</Message>
+        <Message dangerouslySetInnerHTML={{ __html: message }} />
       </ToastContainer>
     ),
     {
       duration: 2000,
-      position: 'top-center',
+      position: 'bottom-center',
     }
   );
 };

--- a/components/Layout/Home/HomeBox/HomeBox.tsx
+++ b/components/Layout/Home/HomeBox/HomeBox.tsx
@@ -117,7 +117,7 @@ const HomeBox = ({
             width={24}
             height={24}
           />
-          캐릭터
+          캐릭터 도감
         </CharacterSelect>
         <CharacterBottomSheet
           isOpen={isBottomSheetOpen}

--- a/components/Layout/Home/HomeBox/HomeBox.tsx
+++ b/components/Layout/Home/HomeBox/HomeBox.tsx
@@ -19,7 +19,7 @@ import Button from '@/components/Common/Button/Button';
 import useCharacterData from '@/hooks/character/useCharacterData';
 import useUserStore from '@/stores/useUserStore';
 import { SuccessToast } from '../Character/SuccessToast';
-import { useCharacterState } from '@/hooks/character/useCharacterState'; // useCharacterState import
+import { useCharacterState } from '@/hooks/character/useCharacterState';
 
 interface HomeBoxProps {
   selectedCharacter: string | null;
@@ -34,7 +34,12 @@ const HomeBox = ({
   setIsBottomSheetOpen,
   isBottomSheetOpen,
 }: HomeBoxProps) => {
-  const { character: activeCharacter, ownCharacters } = useCharacterState();
+  const {
+    character: activeCharacter,
+    ownCharacters,
+    level,
+    exp,
+  } = useCharacterState();
   const [isLocationListVisible, setLocationListVisible] = useState(false);
   const [localSelectedCharacter, setLocalSelectedCharacter] = useState<
     string | null
@@ -93,7 +98,7 @@ const HomeBox = ({
   return (
     <HomeBoxWrapper>
       <TopWrapper>
-        <Level />
+        <Level level={level} exp={exp} />
       </TopWrapper>
       <BottomWrapper>
         <PlaceRegister onClick={toggleLocationList}>

--- a/components/Layout/Home/HomeBox/HomeBox.tsx
+++ b/components/Layout/Home/HomeBox/HomeBox.tsx
@@ -19,6 +19,7 @@ import Button from '@/components/Common/Button/Button';
 import useCharacterData from '@/hooks/character/useCharacterData';
 import useUserStore from '@/stores/useUserStore';
 import { SuccessToast } from '../Character/SuccessToast';
+import { useCharacterState } from '@/hooks/character/useCharacterState'; // useCharacterState import
 
 interface HomeBoxProps {
   selectedCharacter: string | null;
@@ -33,14 +34,14 @@ const HomeBox = ({
   setIsBottomSheetOpen,
   isBottomSheetOpen,
 }: HomeBoxProps) => {
-  const ownCharacters = ['BASIC', 'DOT', 'ANGULAR', 'BUMPY', 'WOOL'];
+  const { character: activeCharacter, ownCharacters } = useCharacterState();
   const [isLocationListVisible, setLocationListVisible] = useState(false);
   const [localSelectedCharacter, setLocalSelectedCharacter] = useState<
     string | null
-  >('BASIC');
+  >(activeCharacter || 'BASIC'); // activeCharacter로 초기화
   const [isButtonVisible, setButtonVisible] = useState(false);
 
-  const characters = useCharacterData({ ownCharacters });
+  const characters = useCharacterData({ ownCharacters }); // ownCharacters 사용
   const userId = useUserStore((state) => state.userId);
 
   // 캐릭터 클릭 처리

--- a/components/Layout/Home/HomeBox/Level.styles.ts
+++ b/components/Layout/Home/HomeBox/Level.styles.ts
@@ -51,7 +51,7 @@ export const ProgressBar = styled.div<{ $progress: number }>`
   background-color: #947dff;
   border-radius: 4px;
   width: 0;
-  animation: fillProgress 1s ease-out forwards;
+  animation: fillProgress 3s ease-out forwards;
 
   @keyframes fillProgress {
     from {

--- a/components/Layout/Home/HomeBox/Level.tsx
+++ b/components/Layout/Home/HomeBox/Level.tsx
@@ -8,13 +8,39 @@ import {
   ProgressNum,
 } from './Level.styles';
 import useUserStore from '@/stores/useUserStore';
-import useCountUp from '@/hooks/Loading/useCountUp';
+import { useCharacterState } from '@/hooks/character/useCharacterState';
 
 export const Level = () => {
-  const level = 1;
-  const progress = useCountUp(30);
-
+  const { level, exp } = useCharacterState(); // 레벨과 경험치 가져오기
   const nickname = useUserStore((state) => state.nickname);
+
+  const levelStandards = [
+    { level: 9, minExp: 2500 },
+    { level: 8, minExp: 2000 },
+    { level: 7, minExp: 1600 },
+    { level: 6, minExp: 1200 },
+    { level: 5, minExp: 900 },
+    { level: 4, minExp: 600 },
+    { level: 3, minExp: 400 },
+    { level: 2, minExp: 200 },
+    { level: 1, minExp: 0 }, // 100 미만의 exp는 레벨 1
+  ];
+
+  // 현재 레벨의 최소 경험치와 다음 레벨의 최소 경험치 가져오기
+  const currentLevelStandard = levelStandards.find(
+    (std) => std.level === level
+  );
+  const nextLevelStandard = levelStandards.find(
+    (std) => std.level === level + 1
+  );
+
+  // 경험치에 따른 게이지 퍼센트 계산
+  const progress =
+    currentLevelStandard && nextLevelStandard
+      ? ((exp - currentLevelStandard.minExp) /
+          (nextLevelStandard.minExp - currentLevelStandard.minExp)) *
+        100
+      : 0;
 
   return (
     <>
@@ -26,7 +52,7 @@ export const Level = () => {
         <ProgressBarContainer>
           <ProgressBar $progress={progress} />
         </ProgressBarContainer>
-        <ProgressNum>{progress}%</ProgressNum>
+        <ProgressNum>{Math.round(progress)}%</ProgressNum>
       </ProgressRow>
     </>
   );

--- a/components/Layout/Home/HomeBox/Level.tsx
+++ b/components/Layout/Home/HomeBox/Level.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from 'react';
 import {
   InfoRow,
   LevelText,
@@ -8,11 +9,15 @@ import {
   ProgressNum,
 } from './Level.styles';
 import useUserStore from '@/stores/useUserStore';
-import { useCharacterState } from '@/hooks/character/useCharacterState';
 
-export const Level = () => {
-  const { level, exp } = useCharacterState(); // 레벨과 경험치 가져오기
+interface LevelProps {
+  level: number;
+  exp: number;
+}
+
+export const Level: React.FC<LevelProps> = ({ level, exp }) => {
   const nickname = useUserStore((state) => state.nickname);
+  const [progress, setProgress] = useState(0);
 
   const levelStandards = [
     { level: 9, minExp: 2500 },
@@ -35,12 +40,16 @@ export const Level = () => {
   );
 
   // 경험치에 따른 게이지 퍼센트 계산
-  const progress =
+  const calculatedProgress =
     currentLevelStandard && nextLevelStandard
       ? ((exp - currentLevelStandard.minExp) /
           (nextLevelStandard.minExp - currentLevelStandard.minExp)) *
         100
       : 0;
+
+  useEffect(() => {
+    setProgress(calculatedProgress);
+  }, [calculatedProgress]);
 
   return (
     <>

--- a/components/Layout/MyPage/ProfileInfo.tsx
+++ b/components/Layout/MyPage/ProfileInfo.tsx
@@ -11,10 +11,14 @@ import Image from 'next/image';
 interface ProfileInfoProps {
   email: string;
   nickname: string;
-  characterType: string;
+  activeCharacter: string;
 }
 
-const ProfileInfo = ({ email, nickname, characterType }: ProfileInfoProps) => {
+const ProfileInfo = ({
+  email,
+  nickname,
+  activeCharacter,
+}: ProfileInfoProps) => {
   return (
     <ProfileInfoWrapper>
       <ImageWrapper>
@@ -22,7 +26,7 @@ const ProfileInfo = ({ email, nickname, characterType }: ProfileInfoProps) => {
       </ImageWrapper>
       <ProfileName>{nickname || '닉네임 없음'}</ProfileName>
       <ProfileEmail>{email || '이메일 없음'}</ProfileEmail>
-      <div>{characterType || '캐릭터 타입 없음'}</div>
+      <div>{activeCharacter || '캐릭터 타입 없음'}</div>
     </ProfileInfoWrapper>
   );
 };

--- a/config/apiEndPointConfig.ts
+++ b/config/apiEndPointConfig.ts
@@ -9,7 +9,7 @@ export const API_URL_CONFIG = {
     NICKNAME: '/api/user-service/users/nickname',
   },
   USER_SERVICE: {
-    CHARACTER: '/api/user-service/users/character',
+    CHARACTER_CHANGE: '/api/user-service/users/character/change',
     USERS: '/api/user-service/users',
   },
   NOTIFICATION: {

--- a/hooks/character/useCharacterState.ts
+++ b/hooks/character/useCharacterState.ts
@@ -3,30 +3,37 @@ import axiosInstance from '@/lib/axios';
 
 interface UseCharacterStateReturn {
   character: string | null;
+  ownCharacters: string[]; // 사용자별 보유 캐릭터 목록
   setCharacter: Dispatch<SetStateAction<string | null>>;
   isLoading: boolean;
 }
 
 interface UseCharacterStateProps {
-  onCharacterLoad?: (characterType: string | null) => void;
+  onCharacterLoad?: (activeCharacter: string | null) => void;
 }
 
 export const useCharacterState = ({
   onCharacterLoad,
 }: UseCharacterStateProps = {}): UseCharacterStateReturn => {
   const [character, setCharacter] = useState<string | null>('BASIC');
+  const [ownCharacters, setOwnCharacters] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchCharacter = async () => {
       try {
         const response = await axiosInstance.get('/api/character');
-        const characterType = response.data.characterType;
-        setCharacter(characterType);
-        onCharacterLoad?.(characterType);
+        const activeCharacter = response.data.activeCharacter;
+        const ownCharacters = response.data.ownedCharacters;
+        console.log('가져온 캐릭터 정보:', response.data);
+
+        setCharacter(activeCharacter);
+        setOwnCharacters(ownCharacters);
+        onCharacterLoad?.(activeCharacter);
       } catch (error) {
         console.error('캐릭터 정보 조회 에러:', error);
         setCharacter('BASIC');
+        setOwnCharacters([]);
         onCharacterLoad?.('BASIC');
       } finally {
         setIsLoading(false);
@@ -36,5 +43,5 @@ export const useCharacterState = ({
     fetchCharacter();
   }, [onCharacterLoad]);
 
-  return { character, setCharacter, isLoading };
+  return { character, setCharacter, isLoading, ownCharacters };
 };

--- a/hooks/character/useCharacterState.ts
+++ b/hooks/character/useCharacterState.ts
@@ -4,6 +4,8 @@ import axiosInstance from '@/lib/axios';
 interface UseCharacterStateReturn {
   character: string | null;
   ownCharacters: string[]; // 사용자별 보유 캐릭터 목록
+  level: number;
+  exp: number;
   setCharacter: Dispatch<SetStateAction<string | null>>;
   isLoading: boolean;
 }
@@ -17,6 +19,8 @@ export const useCharacterState = ({
 }: UseCharacterStateProps = {}): UseCharacterStateReturn => {
   const [character, setCharacter] = useState<string | null>('BASIC');
   const [ownCharacters, setOwnCharacters] = useState<string[]>([]);
+  const [level, setLevel] = useState<number>(1); // 레벨 상태 추가
+  const [exp, setExp] = useState<number>(0); // 경험치 상태 추가
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -25,10 +29,14 @@ export const useCharacterState = ({
         const response = await axiosInstance.get('/api/character');
         const activeCharacter = response.data.activeCharacter;
         const ownCharacters = response.data.ownedCharacters;
+        const userLevel = response.data.level;
+        const userExp = response.data.exp;
         console.log('가져온 캐릭터 정보:', response.data);
 
         setCharacter(activeCharacter);
         setOwnCharacters(ownCharacters);
+        setLevel(userLevel); // 레벨 설정
+        setExp(userExp); // 경험치 설정
         onCharacterLoad?.(activeCharacter);
       } catch (error) {
         console.error('캐릭터 정보 조회 에러:', error);
@@ -43,5 +51,12 @@ export const useCharacterState = ({
     fetchCharacter();
   }, [onCharacterLoad]);
 
-  return { character, setCharacter, isLoading, ownCharacters };
+  return {
+    character,
+    setCharacter,
+    isLoading,
+    ownCharacters,
+    level,
+    exp,
+  };
 };

--- a/hooks/character/useCharacterState.ts
+++ b/hooks/character/useCharacterState.ts
@@ -19,10 +19,9 @@ export const useCharacterState = ({
 }: UseCharacterStateProps = {}): UseCharacterStateReturn => {
   const [character, setCharacter] = useState<string | null>('BASIC');
   const [ownCharacters, setOwnCharacters] = useState<string[]>([]);
-  const [level, setLevel] = useState<number>(1); // 레벨 상태 추가
+  const [level, setLevel] = useState<number | null>(null); // 레벨 상태 추가
   const [exp, setExp] = useState<number>(0); // 경험치 상태 추가
   const [isLoading, setIsLoading] = useState(true);
-
   useEffect(() => {
     const fetchCharacter = async () => {
       try {
@@ -31,7 +30,6 @@ export const useCharacterState = ({
         const ownCharacters = response.data.ownedCharacters;
         const userLevel = response.data.level;
         const userExp = response.data.exp;
-        console.log('가져온 캐릭터 정보:', response.data);
 
         setCharacter(activeCharacter);
         setOwnCharacters(ownCharacters);
@@ -56,7 +54,7 @@ export const useCharacterState = ({
     setCharacter,
     isLoading,
     ownCharacters,
-    level,
+    level: level || 1,
     exp,
   };
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#123 

## 📝 작업 내용
### 1. `/api/user-service/users/{userId}` 변경사항
- `characterType` -> `activeCharacter`로 변경
-  `ownCharacters` 추가 : 캐릭터 도감에 보유 캐릭터로 사용
-  `level` 및 `exp` 추가 : 목업 데이터에서 실제 데이터로 반영

### 2. `/api/user-service/character/change/{userId}` 엔드포인트 추가
- 캐릭터 변경 시 변경 characterType POST
- 기존 `/api/user-service/users/{userId}` 내부에 ownCharacters[]를 분리

### 3. 마이페이지 로그아웃 기능 구현
- 마이페이지 `next-auth/react`의 `SignOut`을 마이페이지 로그아웃 버튼에 추가


## 💬 리뷰 요구사항
LevelUp 안내 Toast의 경우, 인게임 진행 후 게임 종료 시에 받아온 값을 활용하여 추가할 예정입니다.
다들 출시 전까지 화이팅입니다 👊🏻