### PR TITLE
Refactor/#132 사용자 별 캐릭터 타입 Google Map Marker 연동

### DIFF
--- a/app/(nav)/home/page.tsx
+++ b/app/(nav)/home/page.tsx
@@ -10,15 +10,16 @@ import Button from '@/components/Common/Button/Button';
 import EnterArrowIcon from '@/styles/Icon/Home/EnterArrowIcon.svg';
 import UserCharacter from '@/components/Layout/Home/Character/UserCharacter';
 import { useCharacterState } from '@/hooks/character/useCharacterState';
-import useUserStore from '@/stores/useUserStore';
 import LoadingSpinner from '@/components/Common/LoadingSpinner/LoadingSpinner';
 import Link from 'next/link';
 
 const Home = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
-  const { character: selectedCharacter, setCharacter: setSelectedCharacter } =
-    useCharacterState();
-  const activeCharacter = useUserStore((state) => state.activeCharacter);
+  const {
+    character: selectedCharacter,
+    setCharacter: setSelectedCharacter,
+    isLoading,
+  } = useCharacterState();
 
   /* 웹소켓 연결 실행, 연결 상태 가져오기 */
   const { isConnected, connectWebSocket } = useWebSocketStore();
@@ -27,14 +28,12 @@ const Home = () => {
     if (!isConnected) connectWebSocket();
   }, []);
 
-  useEffect(() => {
-    console.log('홈 페이지 - 활성 캐릭터:', activeCharacter);
-  }, [activeCharacter]);
-
   return (
     <>
       <HomePageWrapper>
-        {activeCharacter ? ( // activeCharacter가 빈 문자열이 아닐 때만 렌더링
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
           <>
             <TopWrapper>
               <UserCharacter
@@ -60,8 +59,6 @@ const Home = () => {
               </Link>
             </BottomWrapper>
           </>
-        ) : (
-          <LoadingSpinner />
         )}
       </HomePageWrapper>
     </>

--- a/app/(nav)/home/page.tsx
+++ b/app/(nav)/home/page.tsx
@@ -10,12 +10,15 @@ import Button from '@/components/Common/Button/Button';
 import EnterArrowIcon from '@/styles/Icon/Home/EnterArrowIcon.svg';
 import UserCharacter from '@/components/Layout/Home/Character/UserCharacter';
 import { useCharacterState } from '@/hooks/character/useCharacterState';
+import useUserStore from '@/stores/useUserStore';
+import LoadingSpinner from '@/components/Common/LoadingSpinner/LoadingSpinner';
 import Link from 'next/link';
 
 const Home = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const { character: selectedCharacter, setCharacter: setSelectedCharacter } =
     useCharacterState();
+  const activeCharacter = useUserStore((state) => state.activeCharacter);
 
   /* 웹소켓 연결 실행, 연결 상태 가져오기 */
   const { isConnected, connectWebSocket } = useWebSocketStore();
@@ -24,32 +27,42 @@ const Home = () => {
     if (!isConnected) connectWebSocket();
   }, []);
 
+  useEffect(() => {
+    console.log('홈 페이지 - 활성 캐릭터:', activeCharacter);
+  }, [activeCharacter]);
+
   return (
     <>
       <HomePageWrapper>
-        <TopWrapper>
-          <UserCharacter
-            selectedCharacter={selectedCharacter}
-            isOpen={isBottomSheetOpen}
-          />
-        </TopWrapper>
-        <BottomWrapper>
-          <HomeBox
-            selectedCharacter={selectedCharacter}
-            setSelectedCharacter={setSelectedCharacter}
-            setIsBottomSheetOpen={setIsBottomSheetOpen}
-            isBottomSheetOpen={isBottomSheetOpen}
-          />
-          <Link href="/waitingRoomList">
-            <Button
-              label="방 입장하기"
-              icon={EnterArrowIcon}
-              buttonHeight="long"
-              $iconPosition="right"
-              disabled={!isConnected}
-            />
-          </Link>
-        </BottomWrapper>
+        {activeCharacter ? ( // activeCharacter가 빈 문자열이 아닐 때만 렌더링
+          <>
+            <TopWrapper>
+              <UserCharacter
+                selectedCharacter={selectedCharacter}
+                isOpen={isBottomSheetOpen}
+              />
+            </TopWrapper>
+            <BottomWrapper>
+              <HomeBox
+                selectedCharacter={selectedCharacter}
+                setSelectedCharacter={setSelectedCharacter}
+                setIsBottomSheetOpen={setIsBottomSheetOpen}
+                isBottomSheetOpen={isBottomSheetOpen}
+              />
+              <Link href="/waitingRoomList">
+                <Button
+                  label="방 입장하기"
+                  icon={EnterArrowIcon}
+                  buttonHeight="long"
+                  $iconPosition="right"
+                  disabled={!isConnected}
+                />
+              </Link>
+            </BottomWrapper>
+          </>
+        ) : (
+          <LoadingSpinner />
+        )}
       </HomePageWrapper>
     </>
   );

--- a/components/Layout/Game/GoogleMap.tsx
+++ b/components/Layout/Game/GoogleMap.tsx
@@ -5,9 +5,13 @@ import styled, { css } from 'styled-components';
 import colors from '@/styles/color/palette';
 import UserMarker from '@/styles/Icon/Game/Marker/pin-mine-basic.png';
 import AnswerMarker from '@/styles/Icon/Game/AnswerMarker.svg';
+import useCharacterMarker from '@/hooks/character/useCharacterMarker';
 
 interface MapContainerProps {
   mode: 'game' | 'rank';
+}
+interface GoogleMapProps {
+  markers: Array<{ lat: number; lng: number; characterType: string }>;
 }
 
 interface MapComponentProps {
@@ -49,6 +53,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
   const mapElementRef = useRef<HTMLDivElement>(null);
   const markerRefs = useRef<google.maps.Marker[]>([]);
   const polylineRefs = useRef<google.maps.Polyline[]>([]);
+  const markerIcon = useCharacterMarker();
 
   // 지도 초기화 함수
   const initializeMap = () => {
@@ -99,7 +104,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
       position,
       map: mapRef.current!,
       icon: {
-        url: UserMarker.src,
+        url: markerIcon,
         scaledSize: new google.maps.Size(52, 52),
       },
       animation: google.maps.Animation.DROP,

--- a/components/Layout/LocationRegister/GoogleMap.tsx
+++ b/components/Layout/LocationRegister/GoogleMap.tsx
@@ -3,7 +3,7 @@ import usePlaceRegisterStore from '@/stores/placeRegisterStore';
 import { AdvancedMarker, Map, MapMouseEvent } from '@vis.gl/react-google-maps';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import UserMarkerSrc from '@styles/Icon/Game/UserMarker.svg';
+import useCharacterMarker from '@/hooks/character/useCharacterMarker';
 
 interface GoogleMapProps {
   index: number;
@@ -27,6 +27,8 @@ const GoogleMap = ({
   });
   const { setPlaceInput } = usePlaceRegisterStore();
   const { handleReverseGeocoding } = useConvertLocationToAddress();
+  const markerIcon = useCharacterMarker();
+  console.log('markerIcon', markerIcon);
 
   useEffect(() => {
     // 마커의 위치와 도로명 주소 초기화
@@ -64,7 +66,7 @@ const GoogleMap = ({
       {markerPosition.lat !== 0 && markerPosition.lng !== 0 && (
         <AdvancedMarker position={markerPosition} clickable={true}>
           <Image
-            src={UserMarkerSrc}
+            src={markerIcon}
             width={50}
             height={53}
             alt="UserMarker Icon"

--- a/hooks/character/useCharacterMarker.ts
+++ b/hooks/character/useCharacterMarker.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axios';
+
+const useCharacterType = () => {
+  const [markerIcon, setMarkerIcon] = useState<string>(
+    '/Character/Marker/pin-mine-basic.png'
+  );
+
+  useEffect(() => {
+    const fetchCharacterType = async () => {
+      try {
+        const response = await axiosInstance.get('/api/character');
+        const activeCharacter = response.data.activeCharacter || 'basic';
+        setMarkerIcon(
+          `/Character/Marker/pin-mine-${activeCharacter.toLowerCase()}.png`
+        );
+        console.log('markerIcon', activeCharacter);
+      } catch (error) {
+        console.error('캐릭터 타입 가져오기 실패:', error);
+        setMarkerIcon('/Character/Marker/pin-mine-basic.png'); // 실패 시 기본값 설정
+      }
+    };
+
+    fetchCharacterType();
+  }, []);
+
+  return markerIcon;
+};
+
+export default useCharacterType;

--- a/hooks/character/useCharacterState.ts
+++ b/hooks/character/useCharacterState.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import axiosInstance from '@/lib/axios';
-import useUserStore from '@/stores/useUserStore';
 
 interface UseCharacterStateReturn {
   character: string | null;
@@ -24,8 +23,6 @@ export const useCharacterState = ({
   const [exp, setExp] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(true);
 
-  const { setActiveCharacter } = useUserStore();
-
   useEffect(() => {
     const fetchCharacter = async () => {
       try {
@@ -35,7 +32,6 @@ export const useCharacterState = ({
         const userLevel = response.data.level;
         const userExp = response.data.exp;
 
-        setActiveCharacter(activeCharacter); // 전역 상태 업데이트
         setCharacter(activeCharacter);
         setOwnCharacters(ownCharacters);
         setLevel(userLevel);
@@ -52,7 +48,7 @@ export const useCharacterState = ({
     };
 
     fetchCharacter();
-  }, [onCharacterLoad, setActiveCharacter]);
+  }, [onCharacterLoad]);
 
   return {
     character,

--- a/hooks/character/useCharacterState.ts
+++ b/hooks/character/useCharacterState.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import axiosInstance from '@/lib/axios';
+import useUserStore from '@/stores/useUserStore';
 
 interface UseCharacterStateReturn {
   character: string | null;
-  ownCharacters: string[]; // 사용자별 보유 캐릭터 목록
+  ownCharacters: string[];
   level: number;
   exp: number;
   setCharacter: Dispatch<SetStateAction<string | null>>;
@@ -17,11 +18,14 @@ interface UseCharacterStateProps {
 export const useCharacterState = ({
   onCharacterLoad,
 }: UseCharacterStateProps = {}): UseCharacterStateReturn => {
-  const [character, setCharacter] = useState<string | null>('BASIC');
+  const [character, setCharacter] = useState<string | null>('');
   const [ownCharacters, setOwnCharacters] = useState<string[]>([]);
-  const [level, setLevel] = useState<number | null>(null); // 레벨 상태 추가
-  const [exp, setExp] = useState<number>(0); // 경험치 상태 추가
+  const [level, setLevel] = useState<number | null>(null);
+  const [exp, setExp] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(true);
+
+  const { setActiveCharacter } = useUserStore();
+
   useEffect(() => {
     const fetchCharacter = async () => {
       try {
@@ -31,10 +35,11 @@ export const useCharacterState = ({
         const userLevel = response.data.level;
         const userExp = response.data.exp;
 
+        setActiveCharacter(activeCharacter); // 전역 상태 업데이트
         setCharacter(activeCharacter);
         setOwnCharacters(ownCharacters);
-        setLevel(userLevel); // 레벨 설정
-        setExp(userExp); // 경험치 설정
+        setLevel(userLevel);
+        setExp(userExp);
         onCharacterLoad?.(activeCharacter);
       } catch (error) {
         console.error('캐릭터 정보 조회 에러:', error);
@@ -47,7 +52,7 @@ export const useCharacterState = ({
     };
 
     fetchCharacter();
-  }, [onCharacterLoad]);
+  }, [onCharacterLoad, setActiveCharacter]);
 
   return {
     character,

--- a/stores/useUserStore.ts
+++ b/stores/useUserStore.ts
@@ -3,15 +3,22 @@ import { create } from 'zustand';
 interface UserState {
   userId: number;
   nickname: string;
+  characterType: string;
+  activeCharacter: string | null;
   setUserId: (userId: number) => void;
   setNickname: (nickname: string) => void;
+  setActiveCharacter: (activeCharacter: string | null) => void;
 }
 
 const useUserStore = create<UserState>((set) => ({
   userId: 0,
   nickname: '',
+  characterType: '',
+  activeCharacter: '',
   setUserId: (userId: number) => set({ userId }),
   setNickname: (nickname: string) => set({ nickname }),
+  setCharacterType: (characterType: string) => set({ characterType }),
+  setActiveCharacter: (activeCharacter) => set({ activeCharacter }),
 }));
 
 export default useUserStore;

--- a/stores/useUserStore.ts
+++ b/stores/useUserStore.ts
@@ -3,22 +3,15 @@ import { create } from 'zustand';
 interface UserState {
   userId: number;
   nickname: string;
-  characterType: string;
-  activeCharacter: string | null;
   setUserId: (userId: number) => void;
   setNickname: (nickname: string) => void;
-  setActiveCharacter: (activeCharacter: string | null) => void;
 }
 
 const useUserStore = create<UserState>((set) => ({
   userId: 0,
   nickname: '',
-  characterType: '',
-  activeCharacter: '',
   setUserId: (userId: number) => set({ userId }),
   setNickname: (nickname: string) => set({ nickname }),
-  setCharacterType: (characterType: string) => set({ characterType }),
-  setActiveCharacter: (activeCharacter) => set({ activeCharacter }),
 }));
 
 export default useUserStore;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#132 

## 📝 작업 내용
### 1️⃣ hook`useCharacterMarker.ts` 추가
> 캐릭터가 눈에 띄지 않지만 `Level.2`의 `Angular` 캐릭터 타입이 적용되어있습니다.

<img src="https://github.com/user-attachments/assets/9c86757a-bd5f-42cb-ad30-8b7b5f3ba7e1" height="500">

- 사용자의 `characterType`을 API로부터 가져와서 해당 타입에 맞는 마커 아이콘 경로를 설정하는 역할의 Hook을 제작하였습니다.
- Google Map 컴포넌트에서 해당 Hook을 호출하여 사용자의 캐릭터 타입에 따라 적절한 마커 아이콘을 동적으로 설정해두었습니다.



### 2️⃣ `/home` user데이터 로드 후 페이지 렌딩
기존에는 초기 값으로 셋팅한 값이 먼저 보인 후 데이터를 불러오는 즉시 반영하도록 하였으나 UX를 해친다고 생각하여
`isLoading`을 추가하여 API를 호출하여 데이터(`level`, `activeCharacter`)를 가져오기 전까지 LoadingSpinner를 띄우도록 변경하였습니다.

| 기존 home 로드 | 수정 후 home 로드 |
|-----------------|----------------|
| ![Before isLoading](https://github.com/user-attachments/assets/3ea6ac7d-e7a6-481b-b6c5-459f3aa69b8f) | ![After isLoading](https://github.com/user-attachments/assets/ea255d6c-ce4c-43dc-96d4-a96f5ded5e9a) |


## 💬 리뷰 요구사항
게임 내 rank부분에서는 나의 마커 / 상대 플레이어 마커 여부까지 체크를 해야하나 해당 부분은 인게임에서 소켓으로 메시지를 받아 본 후에
적용방법을 생각해볼 예정입니다.

현재 마커는 `pin-mine-basic.png` `pin-other-basic.png`로 구분할 수 있게 되어있으나 어떤 방법으로 이를 구분할 수 있을지 고민입니다..🥹 응답 데이터 공유해 둘테니 좋은 아이디어가 있다면 공유해주세요..!

```
{
  "roomId": "12345678-abcd-efgh-ijkl-1234567890ab",
  "roundNum": 1,
  "isLast": false, // 혹은 "totalRounds": 2
  "roundScore": [
		{ "rank": 1, "userId": 1, "nickname": "가가가", "score": 150, "characterType": "basic" },
		{ "rank": 2, "userId": 2, "nickname": "나나나", "score": 120, "characterType": "dot" }
  ],
  "totalScore": [
		{ "rank": 1, "userId": 1, "nickname": "가가가", "score": 420, "characterType": "basic" },
		{ "rank": 2, "userId": 2, "nickname": "나나나", "score": 380, "characterType": "dot" }
	]
```