### PR TITLE
Feat/#122: 장소 등록하기에서 커스텀 토스트 적용 및 서버 통신 예외 처리

### DIFF
--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -4,8 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
-  const params = request.nextUrl.searchParams;
-  const userId = params.get('userId');
+  const userId = request.headers.get('User-Id');
 
   try {
     const res = await axiosInstance.post(

--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -46,13 +46,15 @@ const ContentsPage = () => {
       isInitialMount.current = false;
       return;
     }
-
     initLocationList();
     fetchLocationList();
   }, [sortType]);
-  const handleResetSortType = (sortType: 'oldest' | 'recent') => {
-    initLocationList();
-    setSortType(sortType);
+
+  const handleResetSortType = (newSortType: 'oldest' | 'recent') => {
+    if (sortType !== newSortType) {
+      initLocationList();
+      setSortType(newSortType);
+    }
   };
 
   // 모달 로직

--- a/components/Common/Skeleton/Skeleton.styles.ts
+++ b/components/Common/Skeleton/Skeleton.styles.ts
@@ -14,7 +14,7 @@ const loading = keyframes`
 export const SkeletonWrapper = styled.div<{ width: number; height: number }>`
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
-  border-radius: 4px;
+  border-radius: 8px;
   background: rgba(235, 235, 235, 1);
   overflow: hidden;
 `;

--- a/components/Common/Toast/LoadingToast.tsx
+++ b/components/Common/Toast/LoadingToast.tsx
@@ -1,0 +1,26 @@
+import toast from 'react-hot-toast';
+
+const LoadingToast = (callback: Promise<void[]>) => {
+  return toast.promise(
+    callback,
+    {
+      loading: '장소를 등록하는 중입니다...',
+      success: '장소 등록이 완료되었어요!',
+      error: '장소를 등록하지 못했어요',
+    },
+    {
+      style: {
+        minWidth: '360px',
+        background: '#fffaf2',
+        border: '2px solid #ae6b00',
+        color: '#663f00',
+        borderRadius: '999px',
+        padding: '8px 16px',
+      },
+      duration: 4000,
+      position: 'bottom-center',
+    }
+  );
+};
+
+export default LoadingToast;

--- a/components/Common/Toast/LoadingToast.tsx
+++ b/components/Common/Toast/LoadingToast.tsx
@@ -6,7 +6,7 @@ const LoadingToast = (callback: Promise<void[]>) => {
     {
       loading: '장소를 등록하는 중입니다...',
       success: '장소 등록이 완료되었어요!',
-      error: '장소를 등록하지 못했어요',
+      error: '일부 장소를 등록하지 못했어요',
     },
     {
       style: {

--- a/components/Layout/ContentRegister/ImagePreview.styles.ts
+++ b/components/Layout/ContentRegister/ImagePreview.styles.ts
@@ -11,7 +11,7 @@ export const PreviewImage = styled.div`
   width: 60px;
   height: 60px;
   img {
-    border-radius: 4px;
+    border-radius: 8px;
   }
 `;
 

--- a/components/Layout/ContentRegister/ImageUpload.styles.ts
+++ b/components/Layout/ContentRegister/ImageUpload.styles.ts
@@ -5,7 +5,7 @@ export const ImageUploadWrapper = styled.div`
   position: relative;
   width: 60px;
   height: 60px;
-  border-radius: 4px;
+  border-radius: 8px;
   border: 1px solid ${colors.etc.black};
   display: flex;
   flex-direction: column;

--- a/components/Layout/ContentRegister/InputCard.styles.ts
+++ b/components/Layout/ContentRegister/InputCard.styles.ts
@@ -5,7 +5,7 @@ export const PlaceInputWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 4px;
+  border-radius: 8px;
   border: 1px solid #aaabab;
   padding: 12px;
 `;

--- a/components/Layout/ContentRegister/LocationSearchButton.styles.ts
+++ b/components/Layout/ContentRegister/LocationSearchButton.styles.ts
@@ -5,18 +5,18 @@ export const PlaceSearchButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
-  border-radius: 4px;
+  border-radius: 8px;
   border: 1px solid ${colors.gray[70]};
   padding: 12px;
   cursor: pointer;
 `;
 
-export const PlaceTexthButtonWrapper = styled.div`
+export const PlaceTextButtonWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 4px;
-  border-radius: 4px;
+  border-radius: 8px;
   border: 1px solid ${colors.gray[70]};
   padding: 12px;
 `;

--- a/components/Layout/ContentRegister/LocationSearchButton.tsx
+++ b/components/Layout/ContentRegister/LocationSearchButton.tsx
@@ -1,6 +1,6 @@
 import {
   PlaceSearchButtonWrapper,
-  PlaceTexthButtonWrapper,
+  PlaceTextButtonWrapper,
   PlaceResetButton,
   LocationRegisterText,
   LocationText,
@@ -22,14 +22,14 @@ const LocationSearchButton = ({ index, value }: PlaceSearchButtonProps) => {
   return (
     <>
       {value ? (
-        <PlaceTexthButtonWrapper>
+        <PlaceTextButtonWrapper>
           <LocationText onClick={toggleBottomSheet}>{value}</LocationText>
           <PlaceResetButton
             onClick={() => setPlaceInput(index, 'address', null)}
           >
             <ClearIcon />
           </PlaceResetButton>
-        </PlaceTexthButtonWrapper>
+        </PlaceTextButtonWrapper>
       ) : (
         <PlaceSearchButtonWrapper onClick={toggleBottomSheet}>
           <SearchIcon />

--- a/components/Layout/TipModal/TipModal.styles.ts
+++ b/components/Layout/TipModal/TipModal.styles.ts
@@ -10,7 +10,7 @@ export const ModalWrapper = styled.div`
   align-items: flex-start;
   gap: 8px;
 
-  border-radius: 4px;
+  border-radius: 8px;
   background: ${colors.etc.white};
   box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.1);
 

--- a/hooks/contentRegister/useRegisterFiles.ts
+++ b/hooks/contentRegister/useRegisterFiles.ts
@@ -1,8 +1,8 @@
 import usePlaceRegisterStore from '@/stores/contentRegisterStore';
 import exifr from 'exifr';
 import useConvertLocationToAddress from './useConvertLocationToAddress';
-import toast from 'react-hot-toast';
 import useLoadingStore from '@/stores/loadingStore';
+import AlertToast from '@/components/Common/Toast/AlertToast';
 
 interface useUploadFilesProps {
   index: number;
@@ -58,20 +58,18 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
       return;
     }
     if (fileList.length > MAX_CONTENT_COUNT) {
-      toast('최대 3개의 사진만 업로드가 가능해요', {
-        icon: '😱',
-      });
+      AlertToast({ message: '최대 3개의 사진만 업로드가 가능해요' });
     }
 
     // 파일 등록: 최대 개수 제한 설정
     const selectedFileList = Array.from(fileList).slice(0, MAX_CONTENT_COUNT);
 
     if (isOverMemory(selectedFileList)) {
-      toast.error('업로드 가능한 용량을 초과했어요');
+      AlertToast({ message: '업로드 가능한 용량을 초과했어요' });
       throw new Error('업로드 가능한 용량을 초과했어요');
     }
     if (!selectedFileList.every(isImageFile)) {
-      toast.error('이미지만 업로드가 가능해요');
+      AlertToast({ message: '이미지만 업로드가 가능해요' });
       throw new Error('이미지만 업로드가 가능해요');
     }
 
@@ -121,8 +119,8 @@ const useRegisterFiles = ({ index }: useUploadFilesProps) => {
       });
       return;
     }
-    toast('위치 서비스를 활성화하시면, 자동으로 위치를 추가할 수 있어요!', {
-      icon: '👍',
+    AlertToast({
+      message: '위치 서비스를 활성화하시면, 자동으로 위치를 추가할 수 있어요!',
     });
   };
 

--- a/hooks/contentRegister/useUploadFiles.ts
+++ b/hooks/contentRegister/useUploadFiles.ts
@@ -1,45 +1,24 @@
+import LoadingToast from '@/components/Common/Toast/LoadingToast';
 import axiosInstance from '@/lib/axios';
 import usePlaceRegisterStore, { Place } from '@/stores/contentRegisterStore';
-import useUserStore from '@/stores/useUserStore';
 import { useRouter } from 'next/navigation';
-import toast from 'react-hot-toast';
 
 const useUploadFiles = () => {
   const { placeList, initEntirePlaceList } = usePlaceRegisterStore();
-  const { userId } = useUserStore();
   const router = useRouter();
 
   const handleUploadFiles = async () => {
-    // 장소 등록 진행
-    const loadingToast = toast.loading('장소를 등록하는 중입니다...');
-
-    try {
-      for (const place of placeList) {
-        await handleUploadPartFile(place);
-      }
-
-      // 장소 등록 완료
-      toast.remove(loadingToast);
-      toast('장소 등록이 완료되었어요!', {
-        icon: '👍',
-      });
-
-      initEntirePlaceList();
-      router.push('/home');
-    } catch (error) {
-      // 장소 등록 실패
-      console.error(`장소 등록하기에서 발생한 에러: ${error}`);
-      toast.remove(loadingToast);
-      toast('장소를 등록하지 못했어요', {
-        icon: '😱',
-      });
-    }
+    LoadingToast(
+      Promise.all(placeList.map((place) => handleUploadPartFile(place)))
+    )
+      .then(() => {
+        initEntirePlaceList();
+        router.push('/home');
+      })
+      .catch(() => {});
   };
 
   const handleUploadPartFile = async (place: Place) => {
-    const params = new URLSearchParams();
-    params.append('userId', String(userId));
-
     const formData = new FormData();
 
     // 이미지 등록
@@ -56,12 +35,10 @@ const useUploadFiles = () => {
 
     // 서버에게 정보 전송
     await axiosInstance
-      .post('/api/content', formData, { params })
-      .then((response) => {
-        console.log(`장소 등록하기의 서버 통신 상태:${response.status}`);
+      .post('/api/content', formData, {
+        method: 'POST',
       })
       .catch((error) => {
-        console.error('Upload error:', error.response?.data || error.message);
         throw new Error(error);
       });
   };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#122 

## 📝 작업 내용
- border-radius 8px로 통일
- 커스텀 toast 적용
  - 이미지 등록하는 과정에 적용
  - 이미지 서버로 전송하는 과정에 적용
- 이미지 서버로 전송하는 로직 Promise 활용
  - 참고 주소: [Promise all](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Promise)
  - 참고 주소: [Promise allSettled](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
  - 참고 주소: [Promise all VS allSettled](https://inpa.tistory.com/entry/JS-%F0%9F%93%9A-%EB%8D%94%EC%9D%B4%EC%83%81-Promiseall-%EC%93%B0%EC%A7%80%EB%A7%90%EA%B3%A0-PromiseallSettled-%EC%82%AC%EC%9A%A9%ED%95%98%EC%9E%90)

### 📸 스크린샷
|이미지 등록하는 과정|이미지 서버로 전송하는 과정(성공한 경우)|
|:-:|:-:|
|![image](https://github.com/user-attachments/assets/90ddb77d-4f3b-4fb2-9729-9c01c8b32abe)|![250220](https://github.com/user-attachments/assets/aeb13680-7ed1-4b39-9fa6-e8071dddc592)

## 💬 리뷰 요구사항
### 토스트 분리 적용
이미지 등록하는 과정, 이미지 서버로 전송하는 과정에 정적 토스트, 동적 토스트를 분리하여 적용했습니다.
- 이미지 등록하는 과정: 정적 토스트, 기존의 AlertToast 활용
- 이미지 서버로 전송하는 과정: 동적 토스트, 새로운 LoadingToast 생성

### LoadingToast 구현
LoadingToast의 경우, 등록한 장소를 서버에 전송하는 과정에서 사용됩니다. 

서버에 등록한 장소를 전송하는 것은 한 번에 하나씩 사진을 전송하기에 모든 과정이 다 진행되는지 감시하며 성공/실패 여부에 따른 2차적인 처리가 필요한 비동기 로직이 사용됩니다. 비동기 로직 처리 완료 여부에 따라 toast를 실시간으로 반영하도록 설정했습니다.

이를 위해 react-hot-toast의 toast.promise를 활용했습니다. 아이콘의 경우, 동적 애니메이션을 강조하기 위해 내장되어 있는 아이콘을 활용했으며 배경과 border만 커스텀하였습니다.

- loading: Promise 처리 중
- success: Promise resolve
- error: Promise reject

### 이미지 업로드 중 일부 실패에 대한 예외 처리 구현
Promise.all가 아닌 Promise.allSettled를 사용하여, 모든 장소에 대한 업로드를 시도한 후 실패 토스트를 띄운 후 성공한 장소를 삭제하고 실패한 장소만 남겨두며 화면이 이동되지 않도록 구현했습니다.

다음의 예시는 첫 번째 장소 등록은 성공하였으나, 두 번째 장소 등록이 실패한 경우입니다.
- 첫 번째 장소: 제주도 바다
- 두 번째 장소: 제주도 돌담길

|정적인 예시|동적인 예시|
|:-:|:-:|
![image](https://github.com/user-attachments/assets/e62c4a64-a582-441f-a103-f657590b7bc4)|![250222](https://github.com/user-attachments/assets/b9fb9b9a-0d66-46ef-8410-186935951425)

#### Promise all
비동기 작업을 진행하며, 하나의 reject가 발생하면 즉시 실패로 인지하고 catch로 이동합니다. 장소를 3개 등록하려고 할 때, 첫 번째 장소에서 등록이 실패된다면 두 번째, 세 번째 장소의 경우 서버와의 통신을 하지 않고 모두 실패로 처리됩니다.

기존에 사용한 방법이지만, 저희 서비스에서는 장소에 대한 입력에 사용자의 수고가 들어가기에, 모든 장소에 대해 서버 전송을 시도할 가치가 있다고 판단했습니다. 이러한 예외 처리를 위해 Promise.allSettled를 사용하게 되었습니다.

#### Promise allSettled
비동기 작업을 진행하며, 모든 작업이 완료되길 기다립니다. 각각의 작업에서의 결과(resolve 또는 reject)를 객체 배열로 반환받습니다. 

#### 서비스에서 allSettled 활용법
allSettled를 활용해, 모든 작업의 결과를 반환받아 reject의 발생 여부를 확인하게 됩니다.
만일, reject된 작업이 존재하는 경우 일부 작업이 실패되었음을 감지하고 해당 작업에 대한 입력값은 삭제하지 않고 유지하게 됩니다.

즉, 다음과 같이 진행이 됩니다.
- 모든 장소 등록이 성공한 경우
  - 성공 토스트 띄움 
  -  home으로 이동
- 장소 등록이 일부 실패한 경우
  - 실패 토스트 띄움 
  - 등록 실패한 장소의 입력값 유지
  - 장소 등록하기 화면에서 이동하지 않음 