### PR TITLE
Feat: Pull Requset에서 Vercel 미리보기 구현

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,48 @@
+name: Preview
+
+on:
+  pull_request:
+    branches: ['develop']
+
+jobs:
+  vercel-preview:
+    runs-on: ubuntu-latest
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+
+        run: npm install --global vercel@latest
+
+      - name: Get Vercel Environment Variables
+
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+
+        id: deploy
+
+        run: |
+
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > vercel-output.txt
+
+          echo "preview_url=$(cat vercel-output.txt)" >> $GITHUB_OUTPUT
+
+      - name: Comment PR with Preview URL
+
+        uses: thollander/actions-comment-pull-request@v2
+
+        with:
+          message: |
+
+            🪄 Vercel Preview: ${{ steps.deploy.outputs.preview_url }}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#152 

## 🚨 문제 인식
### 기존의 방식
기존의 방식은 Vercel에 배포되어야 확인될 수 있는 기능들이 있을 때, 무조건 develop branch에 merge를 진행해야 했습니다. 만일 의도한대로 동작하지 않는 경우 다시 Pull Request를 생성하여 merge를 진행하는 과정을 무한히 반복했습니다.

### 문제 인식 계기
현재 모바일 환경에서 메타 데이터 추출이 되지 않는 문제가 발생하고 있어, 이를 해결하기 위해선 배포 환경에서 테스트가 필수적입니다. 모바일에선 로컬 환경을 동작하게 할 수 없기 때문이죠. 

하지만 라이브러리의 문제인지 코드 상의 문제인지 원인을 파악하고 해결하기 위한 시도 횟수가 상당할 것으로 예상됩니다. 무한히 증식하는 Bug관련 Pull Request를 감당하는 것은 올바른 협업 방법이 아님을 판단했습니다.

### 문제 해결 방법
불완전한 기능을 develop에 merge하는 행위는 서비스에 치명적인 오류를 발생시킬 수 있기에 위험하며, 반복적으로 Pull Request를 만들어야 하는 개발자들의 경험에도 좋지 않는 방법임을 인식했습니다.

해당 문제를 해결하기 위해, Pull Request를 게시한 경우 자동적으로 Vercel의 미리보기가 뜨는 자동화 기능을 구현할 필요성을 느꼈습니다.

## 📝 작업 내용
Pull Request에서 배포될 Vercel의 미리보기가 뜨는 자동화 기능을 yml을 통해 구현했습니다.

현재 사용하는 환경이 개인 Repository가 아닌 Organization Repository이기에, Vercel bot이 자동적으로 Pull Request에 대한 미리보기를 제안할 수 없습니다.

그렇기에 git actions를 활용해 직접 Vercel이 추적하여 미리보기를 제시할 수 있도록 구현했습니다.

## 💬 리뷰 요구사항
PR에 Vercel 미리보기를 사용할 수 있게 된다면, 무한적으로 생겨나는 PR의 문제점을 극복할 수 있습니다! 😀🙏
