### PR TITLE
feat: Email, CharacterType 전역 상태 관리 추가

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -14,17 +14,27 @@ const LoginPage = () => {
   const { data: session } = useSession();
   const userId = useUserStore((state) => state.userId);
   const nickname = useUserStore((state) => state.nickname);
+  const email = useUserStore((state) => state.email);
+  const { setEmail } = useUserStore();
   const router = useRouter();
 
   // store 값 변화 감지
   useEffect(() => {
-    console.log('로그인 페이지 - 유저 스토어 정보:', { userId, nickname });
+    console.log('로그인 페이지 - 유저 스토어 정보:', {
+      userId,
+      nickname,
+      email,
+    });
 
+    // 이메일 저장
+    if (session?.user?.email) {
+      setEmail(session.user.email);
+    }
     // 로그인된 경우 /home으로 리다이렉션
     if (session) {
       router.push('/home');
     }
-  }, [userId, nickname, session, router]);
+  }, [userId, nickname, session, router, email, setEmail]);
 
   return (
     <LoginWrapper>

--- a/app/(nav)/myPage/page.tsx
+++ b/app/(nav)/myPage/page.tsx
@@ -26,8 +26,11 @@ const MyPage = () => {
   });
 
   const userId = useUserStore((state) => state.userId);
+  const email = useUserStore((state) => state.email);
+  const characterType = useUserStore((state) => state.characterType);
 
-  console.log('userInfo 마이페이지에서 확인:', userInfo);
+  console.log('email 마이페이지에서 확인:', email);
+  console.log('characterType 마이페이지에서 확인:', characterType);
 
   useEffect(() => {
     const fetchUserInfo = async () => {
@@ -65,9 +68,9 @@ const MyPage = () => {
       <MyPageWrapper>
         <ProfileWrapper>
           <ProfileInfo
-            email={userInfo.email}
+            email={userInfo.email || email}
             nickname={userInfo.nickname}
-            activeCharacter={userInfo.activeCharacter}
+            activeCharacter={userInfo.activeCharacter || characterType}
           />
 
           <SmallButtonWrapper>

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -172,6 +172,7 @@ const authOptions: NextAuthOptions = {
       if (user) {
         token.userId = user.userId;
         token.nickname = user.nickname;
+        token.email = user.email;
       }
 
       // 토큰이 만료되지 않았으면 현재 토큰 반환
@@ -196,6 +197,7 @@ const authOptions: NextAuthOptions = {
           accessToken: token.accessToken,
           userId: token.userId,
           nickname: token.nickname,
+          email: token.email,
         },
       };
     },

--- a/hooks/character/useCharacterState.ts
+++ b/hooks/character/useCharacterState.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import axiosInstance from '@/lib/axios';
+import useUserStore from '@/stores/useUserStore';
 
 interface UseCharacterStateReturn {
   character: string | null;
@@ -23,6 +24,8 @@ export const useCharacterState = ({
   const [exp, setExp] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(true);
 
+  const { setCharacterType } = useUserStore();
+
   useEffect(() => {
     const fetchCharacter = async () => {
       try {
@@ -31,11 +34,12 @@ export const useCharacterState = ({
         const ownCharacters = response.data.ownedCharacters;
         const userLevel = response.data.level;
         const userExp = response.data.exp;
-
         setCharacter(activeCharacter);
         setOwnCharacters(ownCharacters);
         setLevel(userLevel);
         setExp(userExp);
+        setCharacterType(activeCharacter);
+
         onCharacterLoad?.(activeCharacter);
       } catch (error) {
         console.error('캐릭터 정보 조회 에러:', error);
@@ -48,7 +52,7 @@ export const useCharacterState = ({
     };
 
     fetchCharacter();
-  }, [onCharacterLoad]);
+  }, [onCharacterLoad, setCharacterType]);
 
   return {
     character,

--- a/stores/useUserStore.ts
+++ b/stores/useUserStore.ts
@@ -3,15 +3,23 @@ import { create } from 'zustand';
 interface UserState {
   userId: number;
   nickname: string;
+  email: string;
+  characterType: string;
   setUserId: (userId: number) => void;
   setNickname: (nickname: string) => void;
+  setEmail: (email: string) => void;
+  setCharacterType: (characterType: string) => void;
 }
 
 const useUserStore = create<UserState>((set) => ({
   userId: 0,
   nickname: '',
+  email: '',
+  characterType: '',
   setUserId: (userId: number) => set({ userId }),
   setNickname: (nickname: string) => set({ nickname }),
+  setEmail: (email: string) => set({ email }),
+  setCharacterType: (characterType: string) => set({ characterType }),
 }));
 
 export default useUserStore;


### PR DESCRIPTION
# #️⃣ 연관된 이슈
#166 

# 📝 작업 내용
> " `useUserStore.ts`에 기존 `userId`, `nickname` 외에 `email`, `characterType` 값을 추가로 전역으로 관리하도록 하였습니다."
> `NextAuth`를 활용하여 로그인을 구현한 만큼 로그인 시 리턴 받은 값들을 전역관리하는데 삽질을 했기에 간단히 정리해보았습니다.

### 1️⃣ email 전역관리 (NextAuth Session)
> NextAuth는 기본적으로 JWT 기반 인증을 사용하며, 로그인한 사용자의 정보를 세션이 아니라 JWT 토큰에 저장하게 됩니다.
그러므로 로그인 후 받은 이메일을 직접 전역 상태 관리 라이브러리로 저장하는 것이 아니라, JWT → 세션을 거쳐 관리해야 합니다.

전역 상태 관리는 페이지 이동 시 초기화될 수 있지만, NextAuth의 세션은 유지되기 때문에
 `/api/user-services/{userId}`로 받은 회원정보 조회 리턴 값 중 email값을 `useUserStore.ts`에 저장하기 보단 다음과 같은
 과정을 통해 전역으로 관리하게되었습니다 🙌

**1. 로그인 성공 시 이메일을 JWT 토큰에 저장**
- jwt 콜백에서 `token.email = user.email`을 추가
- JWT는 NextAuth에서 전역적으로 관리
- 세션(session) 콜백에서 `session.user.email`로 추가

**2. session 콜백에서 `token.email`값을 `session.user.email`에 전달**
- 이를 통해 useSession을 호출하면 어디서든 email을 가져올 수 있도록 반영
- `useSession` 훅을 사용하여 전역적으로 접근 가능

### 2️⃣ characterType 전역관리
캐릭터 타입은 캐릭터 상태관리를 하는`useCharacterState.ts` Hook을 통해 
캐릭터 정보 API 호출 ➡️  호출 정보를 로컬 상태(useState)에 저장 ➡️ 동시에 전역 상태(useUserStore)에 저장하여 다른 컴포넌트에서 사용 가능하도록 구현하였습니다.

## 💬 리뷰 요구사항
<img width="949" alt="스크린샷 2025-02-28 오후 10 59 42" src="https://github.com/user-attachments/assets/ac0f4075-c0ad-422d-ad77-1ac5e7253f1e" />

`mypage`에서 LightHouse 점수가 낮아 이 부분을 전역으로 관리해주셨으면 좋겠다고 하셔서
 작업 후에 LightHouse까지 테스트 해봤는데 백점나왔으니 성공이겠조?! ✌️