### PR TITLE
Feature#/200 소켓 재 연결시 안정화 시퀸스, 라우팅 시스템 일부 변경

### DIFF
--- a/app/game/[roomId]/[round]/roundRank/page.tsx
+++ b/app/game/[roomId]/[round]/roundRank/page.tsx
@@ -135,7 +135,7 @@ const RoundRank = ({
       // 마지막 라운드 시 구독 해제 및 라우팅
       setTimeout(() => {
         unsubscribeFromRoom(String(roomId));
-        router.push('/home');
+        window.location.href = '/home';
       }, 300);
     } else {
       router.push(`/game/${roomId}/${currentRound + 1}`);

--- a/app/game/[roomId]/waitingRoom/page.tsx
+++ b/app/game/[roomId]/waitingRoom/page.tsx
@@ -95,7 +95,7 @@ const WaitingRoom = () => {
         hasJoined.current = true;
       }
     }
-  }, [roomId, subscribeToRoom, sendMessage, userId, setGameId, router]);
+  }, [setRoomData]);
 
   // 상태 업데이트 확인 (디버깅용)
   useEffect(() => {

--- a/app/game/[roomId]/waitingRoom/page.tsx
+++ b/app/game/[roomId]/waitingRoom/page.tsx
@@ -165,8 +165,8 @@ const WaitingRoom = () => {
     );
     isLeaving.current = true;
     unsubscribeFromRoom(String(roomId));
-    router.push('/home');
-  }, [roomId, unsubscribeFromRoom, router]);
+    window.location.href = '/home';
+  }, [roomId, unsubscribeFromRoom]);
 
   // 빈 카드가 disabled 되어야 하는 조건 (방장을 제외한 모든 플레이어가 준비완료 & 초대 모달이 닫힌 경우)
   const shouldDisableEmptyCard =

--- a/config/webSocketConfig.ts
+++ b/config/webSocketConfig.ts
@@ -1,4 +1,5 @@
 export const WEBSOCKET_CONFIG = {
+  WEBSOCKET_URL: 'wss://urdego.site/urdego/connect',
   SUBSCRIBE_ROOM: (roomId: string) => `/urdego/sub/${roomId}`,
   SUBSCRIBE_ERROR: () => `/urdego/sub/error`,
   SUBSCRIBE_NOTIFICATION: (targetId: number) =>

--- a/hooks/websocket/useWebsocketFunctions.ts
+++ b/hooks/websocket/useWebsocketFunctions.ts
@@ -57,11 +57,6 @@ export const useWebSocketFunctions = () => {
     onMessageReceived: (message: WebSocketMessage) => void
   ) => {
     if (client && isConnected) {
-      if (subscribedRoom === roomId) {
-        console.log(`Already subscribed to room: ${roomId}`);
-        return;
-      }
-
       const subscriptionPath = WEBSOCKET_CONFIG.SUBSCRIBE_ROOM(roomId);
       console.log(`Subscribing to room: ${subscriptionPath}`);
 
@@ -70,13 +65,20 @@ export const useWebSocketFunctions = () => {
         onMessageReceived(JSON.parse(message.body));
       });
 
-      // 구독 정보 저장
+      // 로컬 상태에 구독 정보 저장
       setSubscriptions((prev) => ({
         ...prev,
         [roomId]: subscription,
       }));
 
       setSubscribedRoom(roomId);
+
+      // pendingSubscriptions 배열에도 추가하여 재구독 대상에 포함시키기
+      useWebSocketStore.getState().addPendingSubscription({
+        type: 'room',
+        identifier: roomId,
+        callback: onMessageReceived,
+      });
     } else {
       console.warn('WebSocket is not connected.');
     }

--- a/lib/types/pendingSubscription.ts
+++ b/lib/types/pendingSubscription.ts
@@ -1,0 +1,48 @@
+import { WebSocketMessage } from '@/lib/types/websocket';
+import {
+  InviteWebSocketMessage,
+  ErrorWebSocketMessage,
+} from '@/lib/types/notification';
+
+export type SubscriptionType = 'room' | 'notification' | 'error';
+
+/**
+ * 방(room) 구독
+ * - identifier: string
+ * - callback: (message: WebSocketMessage) => void
+ */
+interface RoomSubscription {
+  type: 'room';
+  identifier: string;
+  callback: (message: WebSocketMessage) => void;
+}
+
+/**
+ * 알림(notification) 구독
+ * - identifier: number
+ * - callback: (message: InviteWebSocketMessage) => void
+ */
+interface NotificationSubscription {
+  type: 'notification';
+  identifier: number;
+  callback: (message: InviteWebSocketMessage) => void;
+}
+
+/**
+ * 에러(error) 구독
+ * - identifier: null (식별자 없음)
+ * - callback: (message: ErrorWebSocketMessage) => void
+ */
+interface ErrorSubscription {
+  type: 'error';
+  identifier: null;
+  callback: (message: ErrorWebSocketMessage) => void;
+}
+
+/**
+ * 세 가지 구독 타입을 합친 "차별화된 유니온" 타입
+ */
+export type PendingSubscription =
+  | RoomSubscription
+  | NotificationSubscription
+  | ErrorSubscription;

--- a/stores/useWebSocketStore.ts
+++ b/stores/useWebSocketStore.ts
@@ -91,7 +91,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
     console.log('Attempting WebSocket connection...');
     const client = new Client({
       brokerURL: WEBSOCKET_URL,
-      reconnectDelay: 10000,
+      reconnectDelay: 1000,
       onConnect: () => {
         console.log('WebSocket connected successfully.');
         set({ isConnected: true });

--- a/stores/useWebSocketStore.ts
+++ b/stores/useWebSocketStore.ts
@@ -1,11 +1,18 @@
 import { create } from 'zustand';
 import { Client } from '@stomp/stompjs';
+import { WEBSOCKET_CONFIG } from '@/config/webSocketConfig';
+import { PendingSubscription } from '@/lib/types/pendingSubscription'; // 위에서 만든 타입 임포트
 
 const WEBSOCKET_URL = 'wss://urdego.site/urdego/connect';
 
 interface WebSocketState {
   client: Client | null;
   isConnected: boolean;
+  pendingSubscriptions: PendingSubscription[];
+
+  addPendingSubscription: (subscription: PendingSubscription) => void;
+  clearPendingSubscriptions: () => void;
+  resubscribeAll: () => void;
   connectWebSocket: () => void;
   disconnectWebSocket: () => void;
 }
@@ -13,21 +20,83 @@ interface WebSocketState {
 export const useWebSocketStore = create<WebSocketState>((set, get) => ({
   client: null,
   isConnected: false,
+  pendingSubscriptions: [],
+
+  addPendingSubscription: (subscription) => {
+    set((state) => ({
+      pendingSubscriptions: [...state.pendingSubscriptions, subscription],
+    }));
+  },
+
+  clearPendingSubscriptions: () => {
+    set({ pendingSubscriptions: [] });
+  },
+
+  resubscribeAll: () => {
+    const { client, isConnected, pendingSubscriptions } = get();
+    if (!client || !isConnected) {
+      console.warn('WebSocket not connected. Skipping resubscription.');
+      return;
+    }
+
+    // 차별화된 유니온을 switch로 분기
+    pendingSubscriptions.forEach((sub) => {
+      switch (sub.type) {
+        case 'room': {
+          const subscriptionPath = WEBSOCKET_CONFIG.SUBSCRIBE_ROOM(
+            sub.identifier
+          );
+          console.log(
+            `Resubscribing to room ${sub.identifier}: ${subscriptionPath}`
+          );
+          client.subscribe(subscriptionPath, (message) => {
+            console.log(`Room message received:`, message.body);
+            sub.callback(JSON.parse(message.body));
+          });
+          break;
+        }
+        case 'notification': {
+          const subscriptionPath = WEBSOCKET_CONFIG.SUBSCRIBE_NOTIFICATION(
+            sub.identifier
+          );
+          console.log(
+            `Resubscribing to notification ${sub.identifier}: ${subscriptionPath}`
+          );
+          client.subscribe(subscriptionPath, (message) => {
+            console.log(`Notification received:`, message.body);
+            sub.callback(JSON.parse(message.body));
+          });
+          break;
+        }
+        case 'error': {
+          const subscriptionPath = WEBSOCKET_CONFIG.SUBSCRIBE_ERROR();
+          console.log(`Resubscribing to error: ${subscriptionPath}`);
+          client.subscribe(subscriptionPath, (message) => {
+            console.log(`Error received:`, message.body);
+            sub.callback(JSON.parse(message.body));
+          });
+          break;
+        }
+      }
+    });
+  },
 
   connectWebSocket: () => {
-    if (get().client) {
+    const { client: existingClient } = get();
+    if (existingClient) {
       console.log('WebSocket is already connected.');
       return;
     }
 
     console.log('Attempting WebSocket connection...');
-
     const client = new Client({
       brokerURL: WEBSOCKET_URL,
       reconnectDelay: 10000,
       onConnect: () => {
         console.log('WebSocket connected successfully.');
         set({ isConnected: true });
+        // 연결 복구 시, 저장된 구독 정보를 모두 다시 구독
+        get().resubscribeAll();
       },
       onStompError: (frame) => {
         console.error('STOMP error:', frame);

--- a/stores/useWebSocketStore.ts
+++ b/stores/useWebSocketStore.ts
@@ -3,8 +3,6 @@ import { Client } from '@stomp/stompjs';
 import { WEBSOCKET_CONFIG } from '@/config/webSocketConfig';
 import { PendingSubscription } from '@/lib/types/pendingSubscription';
 
-const WEBSOCKET_URL = 'wss://urdego.site/urdego/connect';
-
 interface WebSocketState {
   client: Client | null;
   isConnected: boolean;
@@ -105,7 +103,7 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
 
     console.log('Attempting WebSocket connection...');
     const client = new Client({
-      brokerURL: WEBSOCKET_URL,
+      brokerURL: WEBSOCKET_CONFIG.WEBSOCKET_URL,
       reconnectDelay: 1000,
       onConnect: () => {
         console.log('WebSocket connected successfully.');

--- a/stores/useWebSocketStore.ts
+++ b/stores/useWebSocketStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { Client } from '@stomp/stompjs';
 import { WEBSOCKET_CONFIG } from '@/config/webSocketConfig';
-import { PendingSubscription } from '@/lib/types/pendingSubscription'; // 위에서 만든 타입 임포트
+import { PendingSubscription } from '@/lib/types/pendingSubscription';
 
 const WEBSOCKET_URL = 'wss://urdego.site/urdego/connect';
 
@@ -22,10 +22,25 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
   isConnected: false,
   pendingSubscriptions: [],
 
-  addPendingSubscription: (subscription) => {
-    set((state) => ({
-      pendingSubscriptions: [...state.pendingSubscriptions, subscription],
-    }));
+  addPendingSubscription: (subscription: PendingSubscription) => {
+    set((state) => {
+      // 이미 같은 type, identifier를 가진 구독이 있는지 확인
+      const isDuplicate = state.pendingSubscriptions.some(
+        (existing) =>
+          existing.type === subscription.type &&
+          existing.identifier === subscription.identifier
+      );
+
+      // 중복이 아니라면 추가
+      if (!isDuplicate) {
+        return {
+          pendingSubscriptions: [...state.pendingSubscriptions, subscription],
+        };
+      }
+
+      // 중복이면 아무것도 안 함
+      return state;
+    });
   },
 
   clearPendingSubscriptions: () => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#200 
## 📝 작업 내용
### 소켓 재 연결시 유저가 구독했었던 단계까지 재 구독하는 로직을 만들었습니다.
- https://www.notion.so/Websocket-TS-Stomp-1b4bba7341bd807f9dfffbd5530ad4bf
- https://www.notion.so/Websocket-JS-1b5bba7341bd8035a7b4d7d512328313
### next.js의 라우팅시스템의 특징에서 오는 문제점을 발견했고 이 문제를 임시 방편으로는 해결했습니다.
- https://www.notion.so/next-js-next-js-URL-1b6bba7341bd80518e07e537c97381e4

## 💬 리뷰 요구사항
next.js의 라우팅시스템의 특징에서 오는 문제점을 임시 방편으로는 해결했습니다. next.js에서 라우터하는 페이지들을 캐싱하면서 이전 라우팅 값들을 유지하면서 동적 url 페이지를 next.js가 식별하도록 만드는 방법을 찾지 못 했습니다...
지금 고쳐놓은 방식은 근본적으로 성능까지 잡으며 해결한 문제 해결 방법이라 보기 어려우며 계속해서 원인을 찾고 해결까지 앞으로 해보겠습니다.